### PR TITLE
Add EXTRA_READER_PRESENCE_CHECK_DELAY to enableReaderMode extras

### DIFF
--- a/app/app/src/main/java/de/stustapay/stustapay/nfc/NfcHandler.kt
+++ b/app/app/src/main/java/de/stustapay/stustapay/nfc/NfcHandler.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.TagLostException
+import android.os.Bundle
 import de.stustapay.stustapay.model.NfcScanFailure
 import de.stustapay.stustapay.model.NfcScanRequest
 import de.stustapay.stustapay.model.NfcScanResult
@@ -35,7 +36,14 @@ class NfcHandler @Inject constructor(
             activity,
             { tag -> handleTag(tag) },
             NfcAdapter.FLAG_READER_NFC_A or NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS,
-            null
+            // some devices send presence heartbeats to the nfc tag.
+            // this heartbeat may be sent in non-cmac-mode - and then a cmac-enabled
+            // chip refuses any further communication.
+            // -> adjust the check delay so we don't usually check for presence during
+            //    a nfc transaction.
+            Bundle().apply {
+                putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, 500)
+            }
         )
     }
 


### PR DESCRIPTION
tl;dr: MF0AES with CMAC (and optionally RID) communication can fail with "tag lost" due to the underlying OS polling the card for presence without CMAC, causing the communication to break up. 

-----

Your friendly neighborhood ticketing system, @pretix, is also currently implementing the only obvious choice of NXP ICs that both ticks the "cheap" and "secure" boxes: MF0AES. So we were quite thrilled to see, that you are too :-)

Since we did encounter an issue where communication with the card would fail ("Tag lost") whenever secure messaging/CMAC was enabled, we did welcome your project quite a bit: it allowed us to verify that we are indeed capable of properly implementing the MF0AES commandset. But that also meant, that we were seeing the same problem also with your app.

The weird thing for us was, that we were seeing different behaviors on different devices:
- On some devices, CMAC-reads would just plainly not work. At all. (Zebra TC26, for example)
- On other devices, doing a few non-CMAC reads (which would fail) and then CMAC-reads would result in a working state (random chinese tabled: ELCLCD WA1053T)

Upon analysis by NXP using a TraceCAse (and confirmed by us using a proxmark3), we would see multiple, un-CMACed reads on page 00 after the successful authentication.

To make things worse: Using a modified version of the taplinx demo app would also work without any issue. However: The taplinx-app is using the older intent-based approach and not the `enableReaderMode()` with callbacks.

And to our surprise, the problem seems to be just there: Depending on the hardware, you are using (and possibly also the OS version running on it), the system is polling the card to make sure it is still present. Unfortunately though, it is polling in the standard, unauthenticated, non-CMACed mode, causing the card to terminate communication.

We managed to solve the issue for now (extended testing needs still to be done) by passing an extra to `enableReaderMode` which explicitly sets the `EXTRA_READER_PRESENCE_CHECK_DELAY`.

While most usages of this extra seem to be using `250` (I am assuming ms?), `500` did yield better compatibility for us.

As far as I can tell, setting this parameter will cause the system to not actively poll the card by itself for at least 500ms. So if we don't care to actively receive "Tag lost"-messages, we could possibly even set the number to drölfzgitausend.  For "tap-read/write-done" scenarios, this should be alright.

But if you are envisioning a "tap; read/write; leave card; do things; time passes; read/write within the same CMAC-session"-scenario, this might possibly fail if the number is too low... Since we do not care (for now) for this scenario, we'll probably not spend too much time researching it.

From what I've heard, you are not currently facing the same issues that I outlined above. But I still wanted to give you a heads-up and an easy solution in case this comes up in the future. However: I would possibly make the `500` configurable ;-)

Looking forward to seeing the system in operation ~soon~ next year!