### PR TITLE
Refactor(core, transactions): Improved TA isolation lvl

### DIFF
--- a/stustapay/bon/generator.py
+++ b/stustapay/bon/generator.py
@@ -67,7 +67,7 @@ class Generator:
                 self.worker_id,
             )
             for row in missing_bons:
-                async with conn.transaction():
+                async with conn.transaction(isoloation="serializable"):
                     await self.process_bon(conn=conn, order_id=row["id"], order_uuid=row["uuid"])
             self.logger.info("Finished generating left-over bons")
 
@@ -80,7 +80,7 @@ class Generator:
                 return
 
             async with self.pool.acquire() as conn:
-                async with conn.transaction():
+                async with conn.transaction(isolation="serializable"):
                     order_uuid = await conn.fetchval("select uuid from ordr where id = $1", bon_id)
                     assert order_uuid is not None
                     await self.process_bon(conn=conn, order_id=bon_id, order_uuid=order_uuid)

--- a/stustapay/core/customer_bank_export.py
+++ b/stustapay/core/customer_bank_export.py
@@ -43,7 +43,7 @@ async def _export_customer_payouts(
     execution_date = execution_date or datetime.date.today() + datetime.timedelta(days=2)
 
     async with db_pool.acquire() as conn:
-        async with conn.transaction():
+        async with conn.transaction(isolation="serializable"):
             event_node = await fetch_event_node_for_node(conn=conn, node_id=event_node_id)
             assert event_node is not None
             assert event_node.event is not None

--- a/stustapay/core/database.py
+++ b/stustapay/core/database.py
@@ -34,14 +34,14 @@ async def check_revision_version(db_pool: asyncpg.Pool):
 
 async def reset_schema(db_pool: asyncpg.Pool):
     async with db_pool.acquire() as conn:
-        async with conn.transaction():
+        async with conn.transaction(isolation="serializable"):
             await conn.execute("drop schema public cascade")
             await conn.execute("create schema public")
 
 
 async def add_data(db_pool: asyncpg.Pool, sql_file: str, data_path: Path = DATA_PATH):
     async with db_pool.acquire() as conn:
-        async with conn.transaction():
+        async with conn.transaction(isolation="serializable"):
             data = data_path.joinpath(sql_file)
             content = data.read_text("utf-8")
             logger.info(f"Applying test data {data}")

--- a/stustapay/core/populate.py
+++ b/stustapay/core/populate.py
@@ -94,7 +94,7 @@ async def load_tags(
 
             if not dry_run:
                 async with db_pool.acquire() as conn:
-                    async with conn.transaction():
+                    async with conn.transaction(isolation="serializable"):
                         await create_user_tags(conn=conn, node_id=node_id, tags=tags)
 
     finally:
@@ -105,7 +105,7 @@ async def create_cash_registers(config: Config, node_id: int, n_registers: int, 
     db_pool = await create_db_pool(config.database)
     try:
         async with db_pool.acquire() as conn:
-            async with conn.transaction():
+            async with conn.transaction(isolation="serializable"):
                 node = await fetch_node(conn=conn, node_id=node_id)
                 assert node is not None
                 for i in range(n_registers):
@@ -124,7 +124,7 @@ async def create_tills(config: Config, node_id: int, n_tills: int, name_format: 
     db_pool = await create_db_pool(config.database)
     try:
         async with db_pool.acquire() as conn:
-            async with conn.transaction():
+            async with conn.transaction(isolation="serializable"):
                 for i in range(n_tills):
                     till_name = name_format.format(i=i + 1)
                     logger.info(f"Creating till: '{till_name}'")

--- a/stustapay/core/service/account.py
+++ b/stustapay/core/service/account.py
@@ -16,6 +16,7 @@ from stustapay.core.service.common.decorators import (
     requires_terminal,
     requires_user,
     with_db_transaction,
+    with_retryable_db_transaction,
 )
 from stustapay.core.service.common.error import InvalidArgument, NotFound
 from stustapay.core.service.transaction import book_transaction
@@ -61,7 +62,7 @@ class AccountService(DBService):
         super().__init__(db_pool, config)
         self.auth_service = auth_service
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_system_accounts(self, *, conn: Connection, node: Node) -> list[Account]:
@@ -71,7 +72,7 @@ class AccountService(DBService):
             node.ids_to_event_node,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_account(self, *, conn: Connection, account_id: int) -> Account:
@@ -81,14 +82,14 @@ class AccountService(DBService):
             raise NotFound(element_typ="account", element_id=str(account_id))
         return account
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_account_by_tag_uid(self, *, conn: Connection, user_tag_uid: int) -> Optional[Account]:
         # TODO: TREE visibility
         return await get_account_by_tag_uid(conn=conn, tag_uid=user_tag_uid)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def find_accounts(self, *, conn: Connection, node: Node, search_term: str) -> list[Account]:
@@ -152,7 +153,7 @@ class AccountService(DBService):
         #     return False
         # return True
 
-    @with_db_transaction
+    @with_retryable_db_transaction(read_only=False)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def update_account_vouchers(

--- a/stustapay/core/service/auth.py
+++ b/stustapay/core/service/auth.py
@@ -64,7 +64,7 @@ class AuthService(DBService):
         encoded_jwt = jwt.encode(to_encode, self.cfg.core.secret_key, algorithm=self.cfg.core.jwt_token_algorithm)
         return encoded_jwt
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     async def get_user_from_token(self, *, conn: Connection, token: str) -> Optional[CurrentUser]:
         token_payload = self.decode_user_jwt_payload(token)
         if token_payload is None:
@@ -79,7 +79,7 @@ class AuthService(DBService):
             token_payload.session_id,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     async def get_customer_from_token(self, *, conn: Connection, token: str) -> Optional[Customer]:
         token_payload = self.decode_customer_jwt_payload(token)
         if token_payload is None:
@@ -109,7 +109,7 @@ class AuthService(DBService):
         encoded_jwt = jwt.encode(to_encode, self.cfg.core.secret_key, algorithm=self.cfg.core.jwt_token_algorithm)
         return encoded_jwt
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     async def get_terminal_from_token(self, *, conn: Connection, token: str) -> Optional[Terminal]:
         token_payload = self.decode_terminal_jwt_payload(token)
         if token_payload is None:

--- a/stustapay/core/service/common/decorators.py
+++ b/stustapay/core/service/common/decorators.py
@@ -30,13 +30,11 @@ def with_db_connection(func: Callable[..., Awaitable[R]]) -> Callable[..., Await
 @overload
 def with_db_transaction(func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[R]]:
     """Case without arguments"""
-    ...
 
 
 @overload
 def with_db_transaction(read_only: bool) -> Callable[[Callable[..., Awaitable[R]]], Callable[..., Awaitable[R]]]:
     """Case with arguments"""
-    ...
 
 
 def with_db_transaction(read_only):

--- a/stustapay/core/service/common/decorators.py
+++ b/stustapay/core/service/common/decorators.py
@@ -1,6 +1,9 @@
+import asyncio
 from functools import wraps
 from inspect import Parameter, signature
-from typing import Awaitable, Callable, Optional, TypeVar
+import logging
+import random
+from typing import Awaitable, Callable, Optional, TypeVar, Union, overload
 
 import asyncpg.exceptions
 
@@ -24,20 +27,45 @@ def with_db_connection(func: Callable[..., Awaitable[R]]) -> Callable[..., Await
     return wrapper
 
 
+@overload
 def with_db_transaction(func: Callable[..., Awaitable[R]]) -> Callable[..., Awaitable[R]]:
+    """Case without arguments"""
+    ...
+
+
+@overload
+def with_db_transaction(read_only: bool) -> Callable[[Callable[..., Awaitable[R]]], Callable[..., Awaitable[R]]]:
+    """Case with arguments"""
+    ...
+
+
+def with_db_transaction(read_only):
+    if callable(read_only):
+        return with_db_isolation_transaction(read_only)
+    else:
+
+        def wrapper(func):
+            return with_db_isolation_transaction(func, read_only=read_only)
+
+        return wrapper
+
+
+def with_db_isolation_transaction(func, read_only: bool = False):
     @wraps(func)
     async def wrapper(self, **kwargs):
         if "conn" in kwargs:
             return await func(self, **kwargs)
 
         async with self.db_pool.acquire() as conn:
-            async with conn.transaction():
+            async with conn.transaction(isolation=None if read_only else "serializable"):
                 return await func(self, conn=conn, **kwargs)
 
     return wrapper
 
 
-def with_retryable_db_transaction(n_retries=3) -> Callable[[Callable[..., Awaitable[R]]], Callable[..., Awaitable[R]]]:
+def with_retryable_db_transaction(
+    n_retries: int = 10, read_only: bool = False
+) -> Callable[[Callable[..., Awaitable[R]]], Callable[..., Awaitable[R]]]:
     def f(func: Callable[..., Awaitable[R]]):
         @wraps(func)
         async def wrapper(self, **kwargs):
@@ -49,10 +77,19 @@ def with_retryable_db_transaction(n_retries=3) -> Callable[[Callable[..., Awaita
                 exception = None
                 while current_retries > 0:
                     try:
-                        async with conn.transaction():
+                        async with conn.transaction(isolation=None if read_only else "serializable"):
                             return await func(self, conn=conn, **kwargs)
-                    except asyncpg.exceptions.DeadlockDetectedError as e:
+                    except (asyncpg.exceptions.DeadlockDetectedError, asyncpg.exceptions.SerializationError) as e:
                         current_retries -= 1
+                        # random quadratic back off, with a max of 1 second
+                        delay = min(random.random() * (n_retries - current_retries) ** 2 * 0.0001, 1.0)
+                        if delay == 1.0:
+                            logging.warning(
+                                "Max waiting time in quadratic back off of one second reached,"
+                                "check if there is any problem with your database transactions."
+                            )
+                        await asyncio.sleep(delay)
+
                         exception = e
 
                 if exception:

--- a/stustapay/core/service/common/decorators.py
+++ b/stustapay/core/service/common/decorators.py
@@ -1,9 +1,9 @@
 import asyncio
-from functools import wraps
-from inspect import Parameter, signature
 import logging
 import random
-from typing import Awaitable, Callable, Optional, TypeVar, Union, overload
+from functools import wraps
+from inspect import Parameter, signature
+from typing import Awaitable, Callable, Optional, TypeVar, overload
 
 import asyncpg.exceptions
 

--- a/stustapay/core/service/config.py
+++ b/stustapay/core/service/config.py
@@ -22,7 +22,7 @@ class ConfigService(DBService):
             sumup_topup_enabled_globally=self.cfg.core.sumup_enabled,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     async def list_config_entries(self, *, conn: Connection) -> list[ConfigEntry]:
         return await conn.fetch_many(ConfigEntry, "select * from config")

--- a/stustapay/core/service/customer/customer.py
+++ b/stustapay/core/service/customer/customer.py
@@ -98,12 +98,12 @@ class CustomerService(DBService):
         )
         return result != "DELETE 0"
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_customer
     async def get_customer(self, *, current_customer: Customer) -> Optional[Customer]:
         return current_customer
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_customer
     async def get_orders_with_bon(self, *, conn: Connection, current_customer: Customer) -> list[OrderWithBon]:
         orders_with_bon = await conn.fetch_many(
@@ -188,7 +188,7 @@ class CustomerService(DBService):
             round(current_customer.balance, 2),
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     async def get_api_config(self, *, conn: Connection, base_url: str) -> CustomerPortalApiConfig:
         node_id = await conn.fetchval(
             "select n.id from node n join event e on n.event_id = e.id where e.customer_portal_url = $1", base_url

--- a/stustapay/core/service/customer/payout.py
+++ b/stustapay/core/service/customer/payout.py
@@ -182,7 +182,7 @@ class PayoutService(DBService):
         self.auth_service = auth_service
         self.config_service = config_service
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_pending_payout_detail(self, *, conn: Connection) -> PendingPayoutDetail:
@@ -195,13 +195,13 @@ class PayoutService(DBService):
             "where c.payout_run_id is null and c.customer_account_id is not null",
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_payout_run_payouts(self, *, conn: Connection, payout_run_id: int) -> list[Payout]:
         return await conn.fetch_many(Payout, "select * from payout where payout_run_id = $1", payout_run_id)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_payout_run_csv(
@@ -222,7 +222,7 @@ class PayoutService(DBService):
             batch_size=batch_size,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_payout_run_sepa_xml(
@@ -264,7 +264,7 @@ class PayoutService(DBService):
         )
         return await conn.fetch_one(PayoutRunWithStats, "select * from payout_run_with_stats where id = $1", run_id)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_payout_runs(self, *, conn: Connection) -> list[PayoutRunWithStats]:

--- a/stustapay/core/service/customer/sumup.py
+++ b/stustapay/core/service/customer/sumup.py
@@ -320,7 +320,7 @@ class SumupService(DBService):
                             continue
 
                         self.logger.debug(f"checking pending checkout {pending_checkout.checkout_reference}")
-                        async with conn.transaction():
+                        async with conn.transaction(isolation="serializable"):
                             status = await self._update_checkout_status(conn=conn, checkout_id=pending_checkout.id)
                             if status != SumupCheckoutStatus.PENDING:
                                 self.logger.info(f"Sumup checkout {pending_checkout.id} updated to status {status}")
@@ -373,7 +373,7 @@ class SumupService(DBService):
 
         return sumup_checkout.status
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_customer
     @requires_sumup_enabled
     async def check_checkout(

--- a/stustapay/core/service/order/stats.py
+++ b/stustapay/core/service/order/stats.py
@@ -38,7 +38,7 @@ class OrderStatsService(DBService):
         super().__init__(db_pool, config)
         self.auth_service = auth_service
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_product_stats(

--- a/stustapay/core/service/product.py
+++ b/stustapay/core/service/product.py
@@ -100,7 +100,7 @@ class ProductService(DBService):
         assert created_product is not None
         return created_product
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     @requires_node()
     async def list_products(self, *, conn: Connection, node: Node) -> list[Product]:
@@ -108,7 +108,7 @@ class ProductService(DBService):
             Product, "select * from product_with_tax_and_restrictions where node_id = any($1)", node.ids_to_event_node
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     @requires_node()
     async def get_product(self, *, conn: Connection, node: Node, product_id: int) -> Optional[Product]:

--- a/stustapay/core/service/tax_rate.py
+++ b/stustapay/core/service/tax_rate.py
@@ -50,13 +50,13 @@ class TaxRateService(DBService):
         assert tax is not None
         return tax
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     @requires_node()
     async def list_tax_rates(self, *, conn: Connection, node: Node) -> list[TaxRate]:
         return await conn.fetch_many(TaxRate, "select * from tax_rate where node_id = any($1)", node.ids_to_event_node)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     @requires_node()
     async def get_tax_rate(self, *, conn: Connection, node: Node, tax_rate_id: int) -> Optional[TaxRate]:

--- a/stustapay/core/service/ticket.py
+++ b/stustapay/core/service/ticket.py
@@ -65,13 +65,13 @@ class TicketService(DBService):
         assert created_ticket is not None
         return created_ticket
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     @requires_node()
     async def list_tickets(self, *, conn: Connection, node: Node) -> list[Ticket]:
         return await conn.fetch_many(Ticket, "select * from ticket where node_id = any($1)", node.ids_to_event_node)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     @requires_node()
     async def get_ticket(self, *, conn: Connection, node: Node, ticket_id: int) -> Optional[Ticket]:

--- a/stustapay/core/service/till/layout.py
+++ b/stustapay/core/service/till/layout.py
@@ -57,7 +57,7 @@ class TillLayoutService(DBService):
 
         return await conn.fetch_one(TillButton, "select * from till_button_with_products where id = $1", button_id)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_buttons(self, *, node: Node, conn: Connection) -> list[TillButton]:
@@ -65,7 +65,7 @@ class TillLayoutService(DBService):
             TillButton, "select * from till_button_with_products where node_id = any($1)", node.ids_to_event_node
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_button(self, *, conn: Connection, node: Node, button_id: int) -> Optional[TillButton]:
@@ -141,7 +141,7 @@ class TillLayoutService(DBService):
         assert till_layout is not None
         return till_layout
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_layouts(self, *, conn: Connection, node: Node) -> list[TillLayout]:
@@ -151,7 +151,7 @@ class TillLayoutService(DBService):
             node.ids_to_event_node,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_layout(self, *, conn: Connection, node: Node, layout_id: int) -> Optional[TillLayout]:

--- a/stustapay/core/service/till/profile.py
+++ b/stustapay/core/service/till/profile.py
@@ -53,7 +53,7 @@ class TillProfileService(DBService):
         assert resulting_profile is not None
         return resulting_profile
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_profiles(self, *, conn: Connection, node: Node) -> list[TillProfile]:
@@ -61,7 +61,7 @@ class TillProfileService(DBService):
             TillProfile, "select * from till_profile where node_id = any($1)", node.ids_to_event_node
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_profile(self, *, conn: Connection, node: Node, profile_id: int) -> Optional[TillProfile]:

--- a/stustapay/core/service/till/register.py
+++ b/stustapay/core/service/till/register.py
@@ -90,13 +90,13 @@ class TillRegisterService(DBService):
         super().__init__(db_pool, config)
         self.auth_service = auth_service
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_cash_register_stockings_admin(self, *, conn: Connection, node: Node) -> list[CashRegisterStocking]:
         return await _list_cash_register_stockings(conn=conn, node=node)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal()
     async def list_cash_register_stockings_terminal(
         self, *, conn: Connection, current_terminal: Terminal
@@ -187,7 +187,7 @@ class TillRegisterService(DBService):
         )
         return result != "DELETE 0"
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal([Privilege.node_administration])
     async def list_cash_registers_terminal(
         self, *, conn: Connection, current_terminal: Terminal, hide_assigned_registers=False
@@ -197,7 +197,7 @@ class TillRegisterService(DBService):
         assert node is not None
         return await _list_cash_registers(conn=conn, node=node, hide_assigned_registers=hide_assigned_registers)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_cash_registers_admin(
@@ -241,7 +241,7 @@ class TillRegisterService(DBService):
         )
         return result != "DELETE 0"
 
-    @with_retryable_db_transaction()
+    @with_retryable_db_transaction(read_only=False)
     @requires_terminal([Privilege.node_administration])
     async def stock_up_cash_register(
         self,
@@ -292,7 +292,7 @@ class TillRegisterService(DBService):
         )
         return True
 
-    @with_retryable_db_transaction()
+    @with_retryable_db_transaction(read_only=False)
     @requires_terminal([Privilege.cash_transport])
     async def modify_cashier_account_balance(
         self,
@@ -349,7 +349,7 @@ class TillRegisterService(DBService):
             amount=amount,
         )
 
-    @with_retryable_db_transaction()
+    @with_retryable_db_transaction(read_only=False)
     @requires_terminal([Privilege.cash_transport])
     async def modify_transport_account_balance(
         self,
@@ -442,7 +442,7 @@ class TillRegisterService(DBService):
         assert reg is not None
         return reg
 
-    @with_retryable_db_transaction()
+    @with_retryable_db_transaction(read_only=False)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def transfer_cash_register_admin(
@@ -453,7 +453,7 @@ class TillRegisterService(DBService):
             conn=conn, node=node, source_cashier_id=source_cashier_id, target_cashier_id=target_cashier_id
         )
 
-    @with_retryable_db_transaction()
+    @with_retryable_db_transaction(read_only=False)
     @requires_terminal()
     async def transfer_cash_register_terminal(
         self, *, conn: Connection, current_terminal: Terminal, source_cashier_tag_uid: int, target_cashier_tag_uid: int

--- a/stustapay/core/service/till/till.py
+++ b/stustapay/core/service/till/till.py
@@ -28,6 +28,7 @@ from stustapay.core.service.common.decorators import (
     requires_terminal,
     requires_user,
     with_db_transaction,
+    with_retryable_db_transaction,
 )
 from stustapay.core.service.common.error import AccessDenied, InvalidArgument, NotFound
 from stustapay.core.service.till.common import create_till, fetch_till
@@ -63,7 +64,7 @@ class TillService(DBService):
         # TODO: TREE visibility
         return await create_till(conn=conn, node_id=node.id, till=till)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_tills(self, *, node: Node, conn: Connection) -> list[Till]:
@@ -71,7 +72,7 @@ class TillService(DBService):
             Till, "select * from till_with_cash_register where node_id = any($1)", node.ids_to_event_node
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_till(self, *, conn: Connection, node: Node, till_id: int) -> Optional[Till]:
@@ -109,7 +110,7 @@ class TillService(DBService):
         )
         return result != "DELETE 0"
 
-    @with_db_transaction
+    @with_retryable_db_transaction(read_only=False)
     async def register_terminal(self, *, conn: Connection, registration_uuid: str) -> TerminalRegistrationSuccess:
         # TODO: TREE visibility
         till = await conn.fetch_maybe_one(Till, "select * from till where registration_uuid = $1", registration_uuid)
@@ -160,7 +161,7 @@ class TillService(DBService):
         if result is None:
             raise InvalidArgument("till does not exist")
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal()
     async def check_user_login(
         self,
@@ -203,7 +204,7 @@ class TillService(DBService):
 
         return available_roles
 
-    @with_db_transaction
+    @with_retryable_db_transaction()
     @requires_terminal()
     async def login_user(
         self,
@@ -247,7 +248,7 @@ class TillService(DBService):
         assert current_user is not None
         return current_user
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal()
     async def get_current_user(self, *, current_user: Optional[CurrentUser]) -> Optional[CurrentUser]:
         return current_user
@@ -264,7 +265,7 @@ class TillService(DBService):
             current_terminal.till.id,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal()
     async def get_user_info(self, *, conn: Connection, current_user: CurrentUser, user_tag_uid: int) -> UserInfo:
         if (
@@ -293,7 +294,7 @@ class TillService(DBService):
             raise InvalidArgument(f"There is no user registered for tag {format_user_tag_uid(user_tag_uid)}")
         return info
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal()
     async def get_terminal_config(
         self, *, conn: Connection, current_terminal: Terminal, node: Node
@@ -368,7 +369,7 @@ class TillService(DBService):
             test_mode_message=self.cfg.core.test_mode_message,
         )
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_terminal()
     async def get_customer(self, *, conn: Connection, current_terminal: Terminal, customer_tag_uid: int) -> Account:
         node = await fetch_node(conn=conn, node_id=current_terminal.till.node_id)

--- a/stustapay/core/service/tree/service.py
+++ b/stustapay/core/service/tree/service.py
@@ -234,12 +234,12 @@ class TreeService(DBService):
         assert node is not None
         return node
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user()
     async def get_tree_for_current_user(self, *, conn: Connection, current_user: CurrentUser) -> Node:
         return await get_tree_for_current_user(conn=conn, user_node_id=current_user.node_id)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user(privileges=[Privilege.node_administration])
     @requires_node()
     async def get_restricted_event_settings(self, *, conn: Connection, node: Node) -> RestrictedEventSettings:

--- a/stustapay/core/service/tse.py
+++ b/stustapay/core/service/tse.py
@@ -58,7 +58,7 @@ class TseService(DBService):
             raise NotFound(element_typ="tse", element_id=str(tse_id))
         return await conn.fetch_one(Tse, "select * from tse where id = $1", tse_id)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def list_tses(self, *, conn: Connection, node: Node) -> list[Tse]:

--- a/stustapay/core/service/user.py
+++ b/stustapay/core/service/user.py
@@ -59,7 +59,7 @@ class UserService(DBService):
     def _check_password(self, password: str, hashed_password: str) -> bool:
         return self.pwd_context.verify(password, hashed_password)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.user_management])
     @requires_node()
     async def list_user_roles(self, *, conn: Connection, node: Node) -> list[UserRole]:
@@ -286,7 +286,7 @@ class UserService(DBService):
         )
         return await self._create_user(conn=conn, node=node, creating_user_id=current_user.id, new_user=user)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.user_management])
     @requires_node()
     async def list_users(self, *, conn: Connection, node: Node) -> list[User]:
@@ -302,7 +302,7 @@ class UserService(DBService):
             raise NotFound(element_typ="user", element_id=str(user_id))
         return user
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.user_management])
     @requires_node()
     async def get_user(self, *, conn: Connection, node: Node, user_id: int) -> Optional[User]:

--- a/stustapay/core/service/user_tag.py
+++ b/stustapay/core/service/user_tag.py
@@ -71,7 +71,7 @@ class UserTagService(DBService):
         # TODO: TREE visibility
         return await create_user_tag_secret(conn=conn, node_id=node.id, secret=new_secret)
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def get_user_tag_detail(self, *, conn: Connection, user_tag_uid: int) -> Optional[UserTagDetail]:
@@ -99,7 +99,7 @@ class UserTagService(DBService):
         assert detail is not None
         return detail
 
-    @with_db_transaction
+    @with_db_transaction(read_only=True)
     @requires_user([Privilege.node_administration])
     @requires_node()
     async def find_user_tags(self, *, conn: Connection, node: Node, search_term: str) -> list[UserTagDetail]:

--- a/stustapay/festivalsimulator/festivalsimulator.py
+++ b/stustapay/festivalsimulator/festivalsimulator.py
@@ -201,7 +201,8 @@ class Simulator:
             async with client.post(
                 "/user/login", json={"user_tag": {"uid": self.admin_tag_uid}, "user_role_id": ADMIN_ROLE_ID}
             ) as resp:
-                assert resp.status == 200
+                if resp.status != 200:
+                    raise RuntimeError(f"Error logging in admin {resp.status = }, payload = {await resp.text()}")
 
             has_cash_register = await db_pool.fetchval(
                 "select exists (select from usr where user_tag_uid = $1 and cash_register_id is not null)",

--- a/stustapay/framework/database.py
+++ b/stustapay/framework/database.py
@@ -282,7 +282,7 @@ async def apply_revisions(
     revisions = SchemaRevision.revisions_from_dir(revision_path)
 
     async with db_pool.acquire() as conn:
-        async with conn.transaction():
+        async with conn.transaction(isolation="serializable"):
             await conn.execute(f"create table if not exists {REVISION_TABLE} (version text not null primary key)")
 
             curr_revision = await conn.fetchval(f"select version from {REVISION_TABLE} limit 1")


### PR DESCRIPTION
- Writing transactions are now serializable
- Read only TA are still database default which is read committed
- read_only can be configured in the TA decorator
- Increased number of retries for failing TAs
- Added random exponential waiting back off for failing TAs