### PR TITLE
fix(payout): avoid zero payout transactions and disallow numbers in account name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,14 @@
       "module": "stustapay",
       "justMyCode": true,
       "args": ["-c", "server.yaml", "-vvv", "simulate", "start"]
+    },
+    {
+      "name": "Python Tests",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "justMyCode": true,
+      "args": ["."]
     }
   ]
 }

--- a/stustapay/core/schema/db_code/0001-views.sql
+++ b/stustapay/core/schema/db_code/0001-views.sql
@@ -113,7 +113,7 @@ create view customers_without_payout_run as
         c.*
     from customer c
     left join payout p on c.id = p.customer_account_id
-    where p.id is null and c.has_entered_info and c.payout_export != false;
+    where p.id is null and c.has_entered_info and c.payout_export != false and round(c.balance, 2) > 0;
 
 create view payout_run_with_stats as
     select

--- a/stustapay/core/schema/db_code/0001-views.sql
+++ b/stustapay/core/schema/db_code/0001-views.sql
@@ -113,7 +113,7 @@ create view customers_without_payout_run as
         c.*
     from customer c
     left join payout p on c.id = p.customer_account_id
-    where p.id is null and (c.iban is not null or round(c.balance - c.donation, 2) = 0) and c.payout_export != false;
+    where p.id is null and c.has_entered_info and c.payout_export != false;
 
 create view payout_run_with_stats as
     select

--- a/stustapay/core/service/customer/payout.py
+++ b/stustapay/core/service/customer/payout.py
@@ -289,8 +289,8 @@ class PayoutService(DBService):
             "   amount => p.amount,"  # this is customers balance minus donation (see payout creation)
             "   vouchers_amount => 0,"
             "   conducting_user_id => $3,"
-            "   description => format('payout run %s cash exit', $1::bigint)) "
-            "from payout_view p where payout_run_id = $1",
+            "   description => format('payout run %s sepa exit', $1::bigint)) "
+            "from payout_view p where payout_run_id = $1 and round(p.amount, 2) > 0",
             payout_run_id,
             sepa_exit_acc.id,
             current_user.id,
@@ -307,7 +307,7 @@ class PayoutService(DBService):
             "   vouchers_amount => 0,"
             "   conducting_user_id => $3,"
             "   description => format('payout run %s donation exit', $1::bigint)) "
-            "from payout_view p where payout_run_id = $1",
+            "from payout_view p where payout_run_id = $1 and round(p.donation, 2) > 0",
             payout_run_id,
             donation_exit_acc.id,
             current_user.id,
@@ -381,7 +381,7 @@ class PayoutService(DBService):
             "   select "
             "       customer_account_id, "
             "       sum(balance - donation) over (order by customer_account_id rows between unbounded preceding and current row) as running_total "
-            "   from customers_without_payout_run p where p.node_id = $2 and p.payout_export and p.balance > 0 "
+            "   from customers_without_payout_run p where p.node_id = $2 and p.payout_export and round(p.balance, 2) > 0 "
             "   order by customer_account_id "
             ") as agr "
             "where running_total <= $1",
@@ -421,7 +421,7 @@ class PayoutService(DBService):
             "               count(*) over (order by customer_account_id rows between unbounded preceding and current row) as index, "
             "               sum(balance - donation) over (order by customer_account_id rows between unbounded preceding and current row) as running_total "
             "           from customers_without_payout_run p "
-            "           where p.node_id = $3 and p.payout_export and p.balance > 0 "
+            "           where p.node_id = $3 and p.payout_export and round(p.balance, 2) > 0 "
             "           order by customer_account_id "
             "        ) as agr where running_total <= $2 and index <= $4 "
             "    )"

--- a/web/apps/customerportal/src/app/routes/PayoutInfo.tsx
+++ b/web/apps/customerportal/src/app/routes/PayoutInfo.tsx
@@ -67,7 +67,7 @@ export const PayoutInfo: React.FC = () => {
       }
     }),
     account_name: z.string().superRefine((val, ctx) => {
-      if (!RegExp("^[a-zA-Z0-9':,\\-()\\/ .]+$").test(val)) {
+      if (!RegExp("^[a-zA-Z':,\\-()\\/ .]+$").test(val)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t("payout.nameHasSpecialChars"),

--- a/web/apps/customerportal/src/locales/de/translations.ts
+++ b/web/apps/customerportal/src/locales/de/translations.ts
@@ -59,7 +59,7 @@ export const translations: NestedPartialAsStrings<Translations> = {
   },
   payout: {
     iban: "IBAN",
-    bankAccountHolder: "Kontoinhaber",
+    bankAccountHolder: "Bankkontoinhaber",
     email: "E-Mail",
     info: "Damit wir dein Restguthaben überweisen können, trage bitte deine Bankdaten hier ein. Du kannst auch einen Teil oder Dein gesamtes Guthaben an uns spenden, um unser ehrenamtliches Engagement zu unterstützen. Kulturleben in der Studentenstadt e.V. is ein von Studierenden betriebener gemeinnütziger Verein, welcher jährlich das StuStaCulum-Festival organisiert. Deine Auszahlung findet voraussichtlich innerhalb eines Monats statt.",
     infoPayoutInitiated: "Du hast deine Bankinformationen bereits angegeben und dein verbleibendes Guthaben wird in der nächsten manuell ausgelösten Auszahlung (in der Regel innerhalb eines Monats) ausgezahlt. Du kannst jedoch weiterhin deine Bankinformationen oder deine Spendenwahl ändern. Vielen Dank für deine Geduld.",

--- a/web/apps/customerportal/src/locales/en/translations.ts
+++ b/web/apps/customerportal/src/locales/en/translations.ts
@@ -55,7 +55,7 @@ export const translations = {
   },
   payout: {
     iban: "IBAN",
-    bankAccountHolder: "Account Holder",
+    bankAccountHolder: "Bank Account Holder",
     email: "E-Mail",
     info: "Please enter your bank account information so we can transfer your leftover balance. You can also donate parts or your whole remaining balance to support our volunteer work. Kulturleben in der Studentenstadt e. V. is a student-run non-profit organization which annually holds the StuStaCulum festival. The payout will happen within approximately one month.",
     infoPayoutInitiated: "You have already provided your bank information and your remaining balance will be payed out in the next manual triggered payout batch (usually within a month). However, you can still edit your bank information or donation choice. Thank you for your patience.",


### PR DESCRIPTION
- does not add accounts with zero balance to payout which avoid zero money transactions in the internal booking system
- clarifies the bank account name filed in frontend
- disallows numbers for bank account name in front end to avoid the input of pin or uid
- adapted tests cases to care about zero payouts