### PR TITLE
fix(core): make pretix webhook more selective

### DIFF
--- a/api/administration.json
+++ b/api/administration.json
@@ -8075,7 +8075,7 @@
       }
     },
     "/webhooks/hook": {
-      "get": {
+      "post": {
         "tags": [
           "webhooks"
         ],
@@ -15175,7 +15175,7 @@
       "WebhookType": {
         "type": "string",
         "enum": [
-          "pretix_order_update"
+          "pretix"
         ],
         "title": "WebhookType"
       }

--- a/stustapay/administration/routers/webhooks.py
+++ b/stustapay/administration/routers/webhooks.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from stustapay.core.http.context import ContextWebhookService
 
@@ -10,5 +10,5 @@ router = APIRouter(
 
 
 @router.post("/hook")
-async def trigger_webhook(webhook_service: ContextWebhookService, token: str):
-    return await webhook_service.trigger_webhook(token=token)
+async def trigger_webhook(webhook_service: ContextWebhookService, token: str, request: Request):
+    return await webhook_service.trigger_webhook(token=token, payload=await request.json())

--- a/stustapay/ticket_shop/pretix.py
+++ b/stustapay/ticket_shop/pretix.py
@@ -1,10 +1,11 @@
 import asyncio
+import enum
 import logging
 from datetime import datetime
 
 import aiohttp
 import asyncpg
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sftkit.database import Connection
 from sftkit.error import ServiceException
 
@@ -39,12 +40,31 @@ class PretixOrderPosition(BaseModel):
     secret: str
 
 
+class PretixOrderStatus(enum.Enum):
+    paid = "p"
+    pending = "n"
+    expired = "e"
+    canceled = "c"
+
+
 class PretixOrder(BaseModel):
     code: str
     event: str
     email: str
     positions: list[PretixOrderPosition]
     datetime: datetime
+    status: PretixOrderStatus
+
+
+class PretixWebhookPayload(BaseModel):
+    notification_id: int
+    organizer: str
+    event: str
+    action: str
+
+
+class PretixOrderWebhookPayload(PretixWebhookPayload):
+    code: str
 
 
 class PretixApi:
@@ -89,6 +109,10 @@ class PretixApi:
             orders.append(PretixOrder.model_validate(item))
         return orders
 
+    async def fetch_order(self, order_code: str) -> PretixOrder | None:
+        resp = await self._get(f"{self.api_base_url}/orders/{order_code}")
+        return PretixOrder.model_validate(resp)
+
     def get_link_to_order(self, order_code: str) -> str:
         return f"{self.base_url}/control/event/{self.organizer}/{self.event}/orders/{order_code}"
 
@@ -113,42 +137,43 @@ class PretixTicketProvider(TicketProvider):
         super().__init__(config, db_pool)
         self.logger = logging.getLogger("pretix_ticket_provider")
 
-    async def _synchronize_tickets_for_node(self, conn: Connection, node: Node):
-        event_settings = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node.id)
-        api = PretixApi.from_event(event_settings)
+    async def _synchronizie_pretix_order(
+        self, conn: Connection, node: Node, api: PretixApi, event_settings: RestrictedEventSettings, order: PretixOrder
+    ):
+        if order.status != PretixOrderStatus.paid:
+            self.logger.debug(
+                f"Skipped importing ticket from pretix order {order.code} as order has status {order.status.name}"
+            )
+            return
+
         assert event_settings.pretix_ticket_ids is not None
         pretix_ticket_product_ids = event_settings.pretix_ticket_ids
+        async with conn.transaction(isolation="serializable"):
+            for position in order.positions:
+                if position.item in pretix_ticket_product_ids:
+                    imported = await self.store_external_ticket(
+                        conn=conn,
+                        node=node,
+                        ticket=CreateExternalTicket(
+                            external_reference=order.code,
+                            created_at=order.datetime,
+                            token=position.secret,
+                            ticket_type=ExternalTicketType.pretix,
+                            external_link=api.get_link_to_order(order.code),
+                        ),
+                    )
+                    if imported:
+                        self.logger.debug(f"Imported ticket from pretix order {order.code}")
+
+    async def _synchronize_tickets_for_node(
+        self, conn: Connection, node: Node, event_settings: RestrictedEventSettings
+    ):
+        api = PretixApi.from_event(event_settings)
         orders = await api.fetch_orders()
         for order in orders:
-            async with conn.transaction(isolation="serializable"):
-                for position in order.positions:
-                    if position.item in pretix_ticket_product_ids:
-                        imported = await self.store_external_ticket(
-                            conn=conn,
-                            node=node,
-                            ticket=CreateExternalTicket(
-                                external_reference=order.code,
-                                created_at=order.datetime,
-                                token=position.secret,
-                                ticket_type=ExternalTicketType.pretix,
-                                external_link=api.get_link_to_order(order.code),
-                            ),
-                        )
-                        if imported:
-                            self.logger.debug(f"Imported ticket from pretix order {order.code}")
-
-    async def synchronize_tickets_for_node(self, node_id: int):
-        async with self.db_pool.acquire() as conn:
-            node = await fetch_node(conn=conn, node_id=node_id)
-            assert node is not None
-            settings = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node_id)
-            if not settings.pretix_presale_enabled:
-                self.logger.warning(
-                    f"Skipping pretix ticket synchronization for event {node.name} as pretix presale is disabled"
-                )
-                return
-            self.logger.debug(f"Synchronizing pretix tickets for event {node.name}")
-            await self._synchronize_tickets_for_node(conn=conn, node=node)
+            await self._synchronizie_pretix_order(
+                conn=conn, node=node, api=api, event_settings=event_settings, order=order
+            )
 
     async def synchronize_tickets(self):
         pretix_enabled = self.config.core.pretix_enabled
@@ -169,12 +194,52 @@ class PretixTicketProvider(TicketProvider):
                     for relevant_node_id in relevant_node_ids:
                         node = await fetch_node(conn=conn, node_id=relevant_node_id)
                         assert node is not None
+                        settings = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node.id)
                         self.logger.debug(f"Synchronizing pretix tickets for event {node.name}")
-                        await self._synchronize_tickets_for_node(conn=conn, node=node)
+                        await self._synchronize_tickets_for_node(conn=conn, node=node, event_settings=settings)
             except Exception:
                 self.logger.exception("process pending orders threw an error")
 
             await asyncio.sleep(self.config.core.pretix_synchronization_interval.seconds)
+
+    async def _handle_pretix_order_paid_webhook(self, node_id: int, payload: PretixOrderWebhookPayload):
+        async with self.db_pool.acquire() as conn:
+            node = await fetch_node(conn=conn, node_id=node_id)
+            assert node is not None
+            settings = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node_id)
+            if not settings.pretix_presale_enabled:
+                self.logger.warning(
+                    f"Skipping pretix ticket synchronization for event {node.name} as pretix presale is disabled"
+                )
+                return
+            if settings.pretix_event != payload.event:
+                self.logger.warning(
+                    f"Received pretix webhook for event {node.name} for a different pretix organizer than was configured in the event"
+                )
+                return
+            if settings.pretix_organizer != payload.organizer:
+                self.logger.warning(
+                    f"Received pretix webhook for event {node.name} for a different pretix event than was configured in the event"
+                )
+                return
+
+            api = PretixApi.from_event(settings)
+            order = await api.fetch_order(order_code=payload.code)
+            await self._synchronizie_pretix_order(conn=conn, node=node, api=api, event_settings=settings, order=order)
+
+    async def pretix_webhook(self, node_id: int, payload: dict):
+        try:
+            validated = PretixWebhookPayload.model_validate(payload)
+
+            if validated.action == "pretix.event.order.paid":
+                try:
+                    order_payload = PretixOrderWebhookPayload.model_validate(payload)
+                    await self._handle_pretix_order_paid_webhook(node_id=node_id, payload=order_payload)
+                except ValidationError:
+                    return
+        except ValidationError:
+            self.logger.info("Received invalid webhook payload from pretix")
+            return
 
 
 async def check_connection(event_settings: RestrictedEventSettings):

--- a/web/apps/administration/src/api/generated/api.ts
+++ b/web/apps/administration/src/api/generated/api.ts
@@ -1330,14 +1330,15 @@ const injectedRtkApi = api
         }),
         providesTags: ["transactions"],
       }),
-      triggerWebhook: build.query<TriggerWebhookApiResponse, TriggerWebhookApiArg>({
+      triggerWebhook: build.mutation<TriggerWebhookApiResponse, TriggerWebhookApiArg>({
         query: (queryArg) => ({
           url: `/webhooks/hook`,
+          method: "POST",
           params: {
             token: queryArg.token,
           },
         }),
-        providesTags: ["webhooks"],
+        invalidatesTags: ["webhooks"],
       }),
     }),
     overrideExisting: false,
@@ -3287,7 +3288,7 @@ export type RestrictedEventSettings = {
 export type GenerateWebhookResponse = {
   webhook_url: string;
 };
-export type WebhookType = "pretix_order_update";
+export type WebhookType = "pretix";
 export type GenerateWebhookPayload = {
   webhook_type: WebhookType;
 };
@@ -3591,6 +3592,5 @@ export const {
   useForceLogoutUserMutation,
   useGetTransactionQuery,
   useLazyGetTransactionQuery,
-  useTriggerWebhookQuery,
-  useLazyTriggerWebhookQuery,
+  useTriggerWebhookMutation,
 } = injectedRtkApi;

--- a/web/apps/administration/src/app/routes/nodes/event-settings/TabPretix.tsx
+++ b/web/apps/administration/src/app/routes/nodes/event-settings/TabPretix.tsx
@@ -104,7 +104,7 @@ export const TabPretix: React.FC<{ nodeId: number; eventSettings: RestrictedEven
   };
 
   const handleGenerateWebhook = () => {
-    generateWebhook({ generateWebhookPayload: { webhook_type: "pretix_order_update" }, nodeId }).then((resp) => {
+    generateWebhook({ generateWebhookPayload: { webhook_type: "pretix" }, nodeId }).then((resp) => {
       if (resp.data) {
         setWebhookUrl(resp.data.webhook_url);
         toast.success(t("settings.pretix.webhookGenerated"));


### PR DESCRIPTION
Only fetch orders from the pretix API which have been explicitly mentioned in the webhook payload.
Include checks to discard webhooks for pretix organizers / events which are not configured in the event settings.

Also changes the pretix integration to only handle pretix orders which have been marked as paid.

closes #435, #434