### PR TITLE
fix(pretix): empty pretix ticket ids as empty list

### DIFF
--- a/stustapay/core/schema/db/0027-pretix-integration.sql
+++ b/stustapay/core/schema/db/0027-pretix-integration.sql
@@ -6,7 +6,7 @@ alter table event add column pretix_shop_url text;
 alter table event add column pretix_api_key text;
 alter table event add column pretix_organizer text;
 alter table event add column pretix_event text;
-alter table event add column pretix_ticket_ids int array;
+alter table event add column pretix_ticket_ids int array not null default '{}';
 
 alter table till_profile add column allow_ticket_vouchers boolean not null default false;
 

--- a/stustapay/festivalsimulator/database_setup.py
+++ b/stustapay/festivalsimulator/database_setup.py
@@ -762,7 +762,7 @@ class DatabaseSetup:
                     pretix_event=None,
                     pretix_organizer=None,
                     pretix_shop_url=None,
-                    pretix_ticket_ids=None,
+                    pretix_ticket_ids=[],
                 ),
             )
             beer_team_node = await create_node(

--- a/stustapay/tests/conftest.py
+++ b/stustapay/tests/conftest.py
@@ -169,7 +169,7 @@ async def event_node(db_connection: Connection) -> Node:
             pretix_event=None,
             pretix_organizer=None,
             pretix_shop_url=None,
-            pretix_ticket_ids=None,
+            pretix_ticket_ids=[],
         ),
     )
 

--- a/stustapay/tests/test_tree.py
+++ b/stustapay/tests/test_tree.py
@@ -80,7 +80,7 @@ async def test_event_creation(tree_service: TreeService, global_admin_token: str
             pretix_event=None,
             pretix_organizer=None,
             pretix_shop_url=None,
-            pretix_ticket_ids=None,
+            pretix_ticket_ids=[],
         ),
     )
     assert event_node.event is not None
@@ -138,7 +138,7 @@ async def test_event_creation(tree_service: TreeService, global_admin_token: str
                 pretix_event=None,
                 pretix_organizer=None,
                 pretix_shop_url=None,
-                pretix_ticket_ids=None,
+                pretix_ticket_ids=[],
             ),
         )
 
@@ -207,7 +207,7 @@ async def test_object_rules(tree_service: TreeService, global_admin_token: str):
             pretix_event=None,
             pretix_organizer=None,
             pretix_shop_url=None,
-            pretix_ticket_ids=None,
+            pretix_ticket_ids=[],
         ),
     )
     assert len(event_node.forbidden_objects_at_node) == 0


### PR DESCRIPTION
Pretix ticket id list was set to null in the beginning which is not supported by FormSelect which lead to an error. Fixed this by setting the default value to an empty list.