### PR TITLE
Revenue overviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ node_modules/
 
 # local
 TODO.md
+*.DS_Store
 
 # nix
 /.direnv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "aiosmtplib==3.0.1",
     "weasyprint==65.0",
     "mako==1.3.9",
+    "pandas==2.2.3"
 ]
 
 [project.scripts]

--- a/stustapay/reports/assets/daily_totals.css
+++ b/stustapay/reports/assets/daily_totals.css
@@ -1,0 +1,101 @@
+* {
+    font-family: sans-serif;
+}
+
+@page {
+    margin: 15mm 0;
+    size: A4;
+
+    @bottom-center {
+        content: counter(page);
+        height: 1cm;
+        text-align: center;
+        width: 1cm;
+    }
+}
+
+@page :first {
+    margin: 0;
+}
+
+body {
+    margin: 0;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+.centered  {
+    text-align: center;
+}
+
+article {
+    margin: 15mm;
+    break-before: always;
+}
+article:first-of-type {
+    break-before: avoid;
+}
+
+#logo {
+    width: 100%;
+    height: 100px;
+    background: no-repeat top left / 200% url('logo.svg');
+}
+
+#header {
+    width: 100%;
+    font-weight: 400;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+#header-name {
+    font-size: 20px;
+}
+#header-title {
+    font-size: 30px;
+}
+#header-event {
+    font-size: 20px;
+}
+
+aside {
+    display: grid;
+    grid: auto auto;
+}
+aside address {
+    font-style: normal;
+    white-space: pre-line;
+}
+aside address#from {
+    grid-column: 1;
+    grid-row: 2;
+    text-align: left;
+}
+aside address#to {
+    grid-column: 2;
+    grid-row: 1;
+    text-align: right;
+}
+
+.overview-table {
+    width: 100%;
+}
+
+#daily-overview {
+    text-align: center;
+}
+
+.daily-revenue-table {
+    width: 100%
+}
+
+.table-header  {
+    border-bottom: 1px solid black;
+}
+
+.transaction-table {
+    width: 100%
+}

--- a/stustapay/reports/assets/daily_totals.html.mako
+++ b/stustapay/reports/assets/daily_totals.html.mako
@@ -1,0 +1,106 @@
+<%
+def format_money(value):
+  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
+
+def format_datetime(value):
+  return value.strftime("%Y-%m-%d %H:%M:%S")
+
+def format_percent(value):
+  return f"{value * 100:5.2f}%".replace(".", ",")
+
+%>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Revenue Report</title>
+    <meta name="description" content="Invoice demo sample">
+  </head>
+
+  <body>
+    % if render_logo:
+      <header id="logo">
+      </header>
+    % endif
+
+    <article>
+
+      <div id="header">
+        <span id="header-name">StuStaPay</span>
+        <span id="header-title">Umsatzbericht</span>
+        <span id="header-event">${event_name}</span>
+      </div>
+
+      <div id="overview">
+        <h3 class="centered">Gesamtübersicht</h3>
+        <table class="overview-table">
+          <tbody>
+            <tr>
+              <td>Beginn</td>
+              <td>${format_datetime(from_time)}</td>
+            </tr>
+            <tr>
+              <td>Letzer berücksichtigter Zeitpunkt</td>
+              <td>${format_datetime(to_time)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div id="base-table">
+        <h3 class="centered">Nach Transaktionsart</h3>
+        <table class="daily-revenue-table">
+          <thead>
+            <tr class="table-header">
+              <th>Art</th>
+              <th>Zahlung</th>
+              <th>Kunden</th>
+              <th>Proukte</th>
+              <th>Summe</th>
+            </tr>
+          </thead>
+          <tbody>
+            % for line in lines_base:
+            <tr>
+              <td>${line["order_type"]}</td>
+              <td>${line["payment_method"]}</td>
+              <td>${line["no_customers"]}</td>
+              <td>${line["no_products"]}</td>
+              <td>${format_money(daily["total_price"])}</td>
+            </tr>
+            % endfor
+          </tbody>
+        </table>
+      </div>
+
+      <div id="location-table">
+        <h3 class="centered">Nach Stand/Ort</h3>
+        <table class="daily-revenue-table">
+          <thead>
+            <tr class="table-header">
+              <th>Art</th>
+              <th>Stand/Ort</th>
+              <th>Zahlung</th>
+              <th>Kunden</th>
+              <th>Proukte</th>
+              <th>Summe</th>
+            </tr>
+          </thead>
+          <tbody>
+            % for line in lines_location:
+            <tr>
+              <td>${line["order_type"]}</td>
+              <td>${line["node_name"]}</td>
+              <td>${line["payment_method"]}</td>
+              <td>${line["no_customers"]}</td>
+              <td>${line["no_products"]}</td>
+              <td>${format_money(daily["total_price"])}</td>
+            </tr>
+            % endfor
+          </tbody>
+        </table>
+      </div>
+    </article>
+
+  </body>
+</html>

--- a/stustapay/reports/assets/daily_totals.html.mako
+++ b/stustapay/reports/assets/daily_totals.html.mako
@@ -55,7 +55,7 @@ def format_percent(value):
               <th>Art</th>
               <th>Zahlung</th>
               <th>Kunden</th>
-              <th>Proukte</th>
+              <th>Produkte</th>
               <th>Summe</th>
             </tr>
           </thead>
@@ -66,13 +66,15 @@ def format_percent(value):
               <td>${line["payment_method"]}</td>
               <td>${line["no_customers"]}</td>
               <td>${line["no_products"]}</td>
-              <td>${format_money(daily["total_price"])}</td>
+              <td>${format_money(line["total_price"])}</td>
             </tr>
             % endfor
           </tbody>
         </table>
       </div>
+    </article>
 
+    <article>
       <div id="location-table">
         <h3 class="centered">Nach Stand/Ort</h3>
         <table class="daily-revenue-table">
@@ -82,7 +84,7 @@ def format_percent(value):
               <th>Stand/Ort</th>
               <th>Zahlung</th>
               <th>Kunden</th>
-              <th>Proukte</th>
+              <th>Produkte</th>
               <th>Summe</th>
             </tr>
           </thead>
@@ -94,7 +96,7 @@ def format_percent(value):
               <td>${line["payment_method"]}</td>
               <td>${line["no_customers"]}</td>
               <td>${line["no_products"]}</td>
-              <td>${format_money(daily["total_price"])}</td>
+              <td>${format_money(line["total_price"])}</td>
             </tr>
             % endfor
           </tbody>

--- a/stustapay/reports/assets/payouts.css
+++ b/stustapay/reports/assets/payouts.css
@@ -1,0 +1,101 @@
+* {
+    font-family: sans-serif;
+}
+
+@page {
+    margin: 15mm 0;
+    size: A4;
+
+    @bottom-center {
+        content: counter(page);
+        height: 1cm;
+        text-align: center;
+        width: 1cm;
+    }
+}
+
+@page :first {
+    margin: 0;
+}
+
+body {
+    margin: 0;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+.centered  {
+    text-align: center;
+}
+
+article {
+    margin: 15mm;
+    break-before: always;
+}
+article:first-of-type {
+    break-before: avoid;
+}
+
+#logo {
+    width: 100%;
+    height: 100px;
+    background: no-repeat top left / 200% url('logo.svg');
+}
+
+#header {
+    width: 100%;
+    font-weight: 400;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+#header-name {
+    font-size: 20px;
+}
+#header-title {
+    font-size: 30px;
+}
+#header-event {
+    font-size: 20px;
+}
+
+aside {
+    display: grid;
+    grid: auto auto;
+}
+aside address {
+    font-style: normal;
+    white-space: pre-line;
+}
+aside address#from {
+    grid-column: 1;
+    grid-row: 2;
+    text-align: left;
+}
+aside address#to {
+    grid-column: 2;
+    grid-row: 1;
+    text-align: right;
+}
+
+.overview-table {
+    width: 100%;
+}
+
+#daily-overview {
+    text-align: center;
+}
+
+.daily-revenue-table {
+    width: 100%
+}
+
+.table-header  {
+    border-bottom: 1px solid black;
+}
+
+.transaction-table {
+    width: 100%
+}

--- a/stustapay/reports/assets/payouts.html.mako
+++ b/stustapay/reports/assets/payouts.html.mako
@@ -41,7 +41,7 @@ def format_percent(value):
             </tr>
             <tr>
               <td>Summe übriger Guthaben</td>
-              <td>${format_money(remaining_balances)}</td>
+              <td>${format_money(remaining_balances["remaining_balances"])}</td>
             </tr>
           </tbody>
         </table>

--- a/stustapay/reports/assets/payouts.html.mako
+++ b/stustapay/reports/assets/payouts.html.mako
@@ -1,0 +1,76 @@
+<%
+def format_money(value):
+  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
+
+def format_date(value):
+  return value.strftime("%Y-%m-%d")
+
+def format_percent(value):
+  return f"{value * 100:5.2f}%".replace(".", ",")
+
+%>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Revenue Report</title>
+    <meta name="description" content="Invoice demo sample">
+  </head>
+
+  <body>
+    % if render_logo:
+      <header id="logo">
+      </header>
+    % endif
+
+    <article>
+
+      <div id="header">
+        <span id="header-name">StuStaPay</span>
+        <span id="header-title">Umsatzbericht</span>
+        <span id="header-event">${event_name}</span>
+      </div>
+
+      <div id="overview">
+        <h3 class="centered">Übersicht Online-Payouts</h3>
+        <table class="overview-table">
+          <tbody>
+            <tr>
+              <td>Stand</td>
+              <td>${format_date(date)}</td>
+            </tr>
+            <tr>
+              <td>Summe übriger Guthaben</td>
+              <td>${format_money(remaining_balances)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div id="base-table">
+        <h3 class="centered">Online-Auszahlungen</h3>
+        <table class="daily-revenue-table">
+          <thead>
+            <tr class="table-header">
+              <th>Ausgeführt am</th>
+              <th>Anzahl Auszahlungen</th>
+              <th>Summe Auszahlungen</th>
+              <th>Summe Spenden</th>
+            </tr>
+          </thead>
+          <tbody>
+            % for payout in payouts:
+            <tr>
+              <td>${format_date(payout["set_done_at"])}</td>
+              <td>${line["n_payouts"]}</td>
+              <td>${format_money(line["total_payout_amount"])}</td>
+              <td>${format_money(line["total_donation_amount"])}</td>
+            </tr>
+            % endfor
+          </tbody>
+        </table>
+      </div>
+    </article>
+
+  </body>
+</html>

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -1,24 +1,17 @@
-from datetime import datetime, timedelta
-import pandas as pd
-import psycopg2 as psy
 from calendar import day_name
+from datetime import datetime, timedelta
+from typing import Optional
 
+import numpy as np
+import pandas as pd
 from pydantic import BaseModel
 from sftkit.database import Connection
 
-from stustapay.bon.bon import BonConfig, gen_dummy_order
+from stustapay.bon.bon import BonConfig
 from stustapay.core.currency import get_currency_symbol
 from stustapay.core.schema.media import Blob
-from stustapay.core.schema.order import Order
-from stustapay.core.schema.tree import Node, RestrictedEventSettings
+from stustapay.core.schema.tree import RestrictedEventSettings
 from stustapay.core.service.media import fetch_blob
-from stustapay.core.service.order.stats import (
-    Timeseries,
-    TimeseriesStatsQuery,
-    get_daily_stats,
-    get_event_time_bounds,
-    get_hourly_sales_stats,
-)
 from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
 from stustapay.reports.render import render_report
 
@@ -26,8 +19,8 @@ from stustapay.reports.render import render_report
 class DailyRevenueLineBase(BaseModel):
     order_type: str
     payment_method: str
-    no_customers: float
-    no_products: float
+    no_customers: int
+    no_products: int
     total_price: float
 
 
@@ -35,8 +28,8 @@ class DailyRevenueLineLocation(BaseModel):
     order_type: str
     node_name: str
     payment_method: str
-    no_customers: float
-    no_products: float
+    no_customers: int
+    no_products: int
     total_price: float
 
 
@@ -51,26 +44,50 @@ class DailyReportContext(BaseModel):
     currency_symbol: str
 
 
-async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
+class OrderDaily(BaseModel):
+    order_id: int
+    booked_at: datetime
+    payment_method: str
+    order_type: str
+    cancels_order: Optional[int]
+    quantity: Optional[int]
+    total_price: Optional[float]
+    node_name: str
+    product_name: Optional[str]
 
-    #TODO: Make query work
+
+async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
     query_string = """
-            select o.id as order_id, uuid, item_count, booked_at, payment_method, o.z_nr, order_type, cancels_order, cashier_id, o.cash_register_id, till_id, o.customer_account_id, item_id, product_id, product_price, quantity, tax_name, tax_rate, total_price, total_tax, t.name as till_name, t.node_id as till_node_id, p.name as product_name, price_in_vouchers, u.login as cashier_login, u.display_name as cashier_name
-            from order_items o
-            left join till t on o.till_id = t.id
-            left join product p on o.product_id = p.id
-            left join usr u on o.cashier_id = u.id
-        """
-    conn_ = psy.connect(**conn)
-    data_all = pd.read_sql_query(query_string, conn_)
+        select o.id as order_id, booked_at, payment_method, order_type, cancels_order, quantity, total_price, n.name as node_name, p.name as product_name
+        from order_items o
+        left join till t on o.till_id = t.id
+        left join product p on o.product_id = p.id
+        left join usr u on o.cashier_id = u.id
+        left join node n on t.node_id = n.id
+    """
+    orders = await conn.fetch_many(OrderDaily, query_string)
+    data_all = pd.DataFrame(
+        {
+            "order_id": [line.order_id for line in orders],
+            "booked_at": [pd.to_datetime(line.booked_at) for line in orders],
+            "payment_method": [line.payment_method for line in orders],
+            "order_type": [line.order_type for line in orders],
+            "cancels_order": [line.cancels_order for line in orders],
+            "quantity": [line.quantity for line in orders],
+            "total_price": [line.total_price for line in orders],
+            "node_name": [line.node_name for line in orders],
+            "product_name": [line.product_name for line in orders],
+        }
+    )
 
     # get weekday (everything before 7AM counts to previous day)
-    data_all["weekday"] = data_all["booked_at_cest"].dt.dayofweek
-    data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "weekday"] -= 1
+    data_all["weekday"] = data_all["booked_at"].dt.dayofweek
+    data_all.loc[data_all["booked_at"].dt.hour < 7, "weekday"] -= 1
     data_all["weekday"] = data_all["weekday"].apply(lambda x: day_name[int(x)])
-    data_all["date"] = data_all["booked_at_cest"].dt.normalize()
+    data_all["date"] = data_all["booked_at"].dt.normalize()
+    # TODO: Get day start/end from tree
     if day_starts_at_7:
-        data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "date"] -= timedelta(days=1)
+        data_all.loc[data_all["booked_at"].dt.hour < 7, "date"] -= timedelta(days=1)
     data_all["date"] = data_all["date"].dt.date
 
     # remove canceled sales
@@ -79,63 +96,99 @@ async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.Da
     data_all = data_all[data_all["order_type"] != "cancel_sale"]
 
     all_relevant_transactions = data_all[
-        data_all["order_type"].isin(["sale", "ticket", "top_up", "pay_out", "money_transfer_imbalance"])].copy()
+        data_all["order_type"].isin(["sale", "ticket", "top_up", "pay_out", "money_transfer_imbalance"])
+    ].copy()
 
-    #TODO: How to add location categories?
-    locations_internal = list(ut.location_color_palette_internal.keys())
-    locations_external = list(ut.external_dict.keys())
+    # TODO: How to add location categories?
+    location_color_palette_internal = {
+        "Brotladen": "peru",
+        "Cocktailzelt": "darkorchid",
+        "Cubalounge": "red",
+        "Festzelt": "lightskyblue",
+        "Infozelt": "darkgrey",
+        "Kade": "gold",
+        "Weißbierkarussell": "darkgreen",
+        "MKH Ausschank": "darkred",
+        "Pfandkasse": "black",
+        "Potzelt": "darkorange",
+        "Tribühne": "darkred",
+        "Turniere": "palegreen",
+        "Weinzelt": "pink",
+        "Weißbierinsel": "mediumblue",
+        # 'StuStaCulum 2024': "orchid",
+    }
+
+    external_dict = {
+        "Sunny's Churros": "Sunny's Churros",
+        "Cheese & Beef": "Cheese & Beef",
+        "Mezze Kebap": "Mezze Kebap",
+        "Holzofendinnede Abt": "Holzofendinnede",
+        "Event Gastronomie Weiß": "Crepes",
+        "Kati’s Tolle Knolle": "Kati’s Tolle Knolle",
+        "Christian UG": "Fish & Chips",
+        "Der Zwerg": "Guaranawein",
+        "Ümit Patir": "Kartoffelchips",
+        "Ayur Aahar": "Indian Streetfood",
+        "Tobias Mörtl": "Kartoffelpuffer",
+        "Coni's Schwenkgrill": "Coni's Schwenkgrill",
+        "Kreitz": "Pizzabaguette",
+    }
+    locations_internal = list(location_color_palette_internal.keys())
+    locations_external = list(external_dict.keys())
 
     all_relevant_transactions["sale_type"] = ""
-    all_relevant_transactions.loc[
-        all_relevant_transactions["node_name"].isin(locations_internal), "sale_type"] = "Verkauf interne Stände"
-    all_relevant_transactions.loc[
-        all_relevant_transactions["node_name"].isin(locations_external), "sale_type"] = "Verkauf externe Stände"
+    all_relevant_transactions.loc[all_relevant_transactions["node_name"].isin(locations_internal), "sale_type"] = (
+        "Verkauf interne Stände"
+    )
+    all_relevant_transactions.loc[all_relevant_transactions["node_name"].isin(locations_external), "sale_type"] = (
+        "Verkauf externe Stände"
+    )
     all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "ticket", "sale_type"] = "Eintrittsticket"
+    all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "top_up", "sale_type"] = (
+        "Aufladung Guthaben"
+    )
+    all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "pay_out", "sale_type"] = (
+        "Auszahlung Guthaben"
+    )
     all_relevant_transactions.loc[
-        all_relevant_transactions["order_type"] == "top_up", "sale_type"] = "Aufladung Guthaben"
-    all_relevant_transactions.loc[
-        all_relevant_transactions["order_type"] == "pay_out", "sale_type"] = "Auszahlung Guthaben"
-    all_relevant_transactions.loc[
-        all_relevant_transactions["order_type"] == "money_transfer_imbalance", "sale_type"] = "Fehlbetrag Barkassen"
-    all_relevant_transactions.loc[all_relevant_transactions["sale_type"] == "", "sale_type"] = "Verkauf interne Stände"
+        all_relevant_transactions["order_type"] == "money_transfer_imbalance", "sale_type"
+    ] = "Fehlbetrag Barkassen"
+    all_relevant_transactions.loc[all_relevant_transactions["sale_type"] == "", "sale_type"] = "Sonstige"
 
     return all_relevant_transactions
 
 
-async def make_daily_table(all_transactions: pd.DataFrame, date: str, break_down_locations: bool = False, break_down_products: bool = False,
-                     break_down_payment_methods: bool = False) -> (pd.DataFrame, datetime.date):
+async def make_daily_table(
+    all_transactions: pd.DataFrame,
+    date: str,
+    break_down_locations: bool = False,
+    break_down_products: bool = False,
+    break_down_payment_methods: bool = False,
+) -> (pd.DataFrame, datetime.date):
     date_obj = datetime.strptime(date, "%Y-%m-%d").date()
     day_transactions = all_transactions[all_transactions["date"] == date_obj].reset_index()
 
     group_by = ["sale_type"]
-    index_names = ["Art"]
     if break_down_locations:
         group_by.append("node_name")
-        index_names.append("Stand/Ort")
     if break_down_products:
         group_by.append("product_name")
-        index_names.append("Produkt")
     if break_down_payment_methods:
         group_by.append("payment_method")
-        index_names.append("Zahlung")
 
-    daily_table = day_transactions.groupby(group_by).agg({
-        "order_id": pd.Series.nunique,
-        "quantity": lambda x: int(sum(x)),
-        "total_price": lambda x: sum(x)
-    })
-    daily_table.columns = ["Kunden", "Produkte", "Summe"]
-    daily_table.index.set_names(index_names, inplace=True)
+    daily_table = (
+        day_transactions.groupby(group_by)
+        .agg({"order_id": pd.Series.nunique, "quantity": lambda x: int(np.sum(x)), "total_price": lambda x: np.sum(x)})
+        .reset_index()
+    )
 
     return daily_table, date_obj
 
 
-async def generate_dummy_daily_report(day: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
+async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
     """Generate a dummy bon for the given event and return the pdf as bytes"""
-    fee = 0.01
-
     ctx = DailyReportContext(
-        event_name=event.name,
+        event_name=event.bon_title,
         render_logo=logo is not None,
         config=BonConfig(
             title=event.bon_title,
@@ -143,43 +196,89 @@ async def generate_dummy_daily_report(day: str, event: RestrictedEventSettings, 
             address=event.bon_address,
             ust_id=event.ust_id,
         ),
-        orders=[
-            OrderWithFees(
-                **dummy_order.model_dump(),
-                fees=dummy_order.total_price * fee,
-                total_price_minus_fees=dummy_order.total_price - dummy_order.total_price * fee,
-            )
-            for dummy_order in dummy_orders
-        ],
-        daily_revenue_stats=[
-            DailyRevenue(
-                day="Monday 2024-10-10",
-                revenue=10212,
-                fees=10212 * fee,
-                revenue_minus_fees=10212 - 10212 * fee,
-            ),
-            DailyRevenue(
-                day="Tuesday 2024-10-11",
-                revenue=3000.23,
-                fees=3000.23 * fee,
-                revenue_minus_fees=3000.23 - 3000.23 * fee,
-            ),
-        ],
         from_time=datetime.now() - timedelta(days=3),
         to_time=datetime.now(),
-        total_revenue=13212.23,
-        fees=13212.23 * fee,
-        fees_percent=fee,
-        revenue_minus_fees=13212.23 - 13212.23 * fee,
         currency_symbol=get_currency_symbol(event.currency_identifier),
+        lines_base=[
+            DailyRevenueLineBase(
+                order_type="Ticket",
+                payment_method="Bar",
+                no_customers=100,
+                no_products=120,
+                total_price=10 * 120,
+            ),
+            DailyRevenueLineBase(
+                order_type="Ticket",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=10 * 210,
+            ),
+            DailyRevenueLineBase(
+                order_type="Topup",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=17.67 * 210,
+            ),
+            DailyRevenueLineBase(
+                order_type="Sales",
+                payment_method="Tag",
+                no_customers=320,
+                no_products=470,
+                total_price=10475.74,
+            ),
+        ],
+        lines_location=[
+            DailyRevenueLineLocation(
+                order_type="Ticket",
+                node_name="EntryTopup",
+                payment_method="Bar",
+                no_customers=100,
+                no_products=120,
+                total_price=10 * 120,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Ticket",
+                node_name="EntryTopup",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=10 * 210,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Topup",
+                node_name="EntryTopup",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=17.67 * 210,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Sales",
+                node_name="Festzelt",
+                payment_method="Tag",
+                no_customers=200,
+                no_products=350,
+                total_price=10475.74 * 2 / 3,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Sales",
+                node_name="WBI",
+                payment_method="Tag",
+                no_customers=120,
+                no_products=470,
+                total_price=10475.74 * 1 / 3,
+            ),
+        ],
     )
     files = {}
     if logo:
         files["logo.svg"] = logo
-    return await render_report(template="report", template_context=ctx.model_dump(), files=files)
+    return await render_report(template="daily_totals", template_context=ctx.model_dump(), files=files)
 
 
-async def generate_daily_report(conn: Connection, date: str, save_location: str = "", day_starts_at_7: bool = True):
+async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True):
     node = await fetch_node(conn=conn, node_id=1)
     assert node is not None
     assert node.event_node_id is not None
@@ -192,17 +291,41 @@ async def generate_daily_report(conn: Connection, date: str, save_location: str 
         date,
         break_down_locations=False,
         break_down_products=False,
-        break_down_payment_methods=True
+        break_down_payment_methods=True,
     )
+    lines_base_table = []
+    for line in daily_base_table.itertuples():
+        lines_base_table.append(
+            DailyRevenueLineBase(
+                order_type=line.sale_type,
+                payment_method=line.payment_method,
+                no_customers=line.order_id,
+                no_products=line.quantity,
+                total_price=line.total_price,
+            )
+        )
 
     daily_location_table, _ = await make_daily_table(
         all_relevant_transactions,
         date,
         break_down_locations=True,
         break_down_products=False,
-        break_down_payment_methods=True
+        break_down_payment_methods=True,
     )
+    lines_location_table = []
+    for line in daily_location_table.itertuples():
+        lines_location_table.append(
+            DailyRevenueLineLocation(
+                order_type=line.sale_type,
+                node_name=line.node_name,
+                payment_method=line.payment_method,
+                no_customers=line.order_id,
+                no_products=line.quantity,
+                total_price=line.total_price,
+            )
+        )
 
+    # TODO: Get day start/end from tree
     if day_starts_at_7:
         from_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(hours=7)
         to_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(days=1, hours=7)
@@ -218,11 +341,11 @@ async def generate_daily_report(conn: Connection, date: str, save_location: str 
         logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
 
     context = DailyReportContext(
-        event_name=event.node_name,
+        event_name=event.bon_title,
         render_logo=logo is not None,
         config=config,
-        lines_base=None,
-        lines_location=None,
+        lines_base=lines_base_table,
+        lines_location=lines_location_table,
         from_time=from_time,
         to_time=to_time,
         currency_symbol=get_currency_symbol(event.currency_identifier),
@@ -231,5 +354,5 @@ async def generate_daily_report(conn: Connection, date: str, save_location: str 
     if logo:
         files["logo.svg"] = logo
 
-    #TODO: Specify save location
+    # TODO: Specify save location
     return await render_report(template="daily_totals", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -278,7 +278,7 @@ async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings,
     return await render_report(template="daily_totals", template_context=ctx.model_dump(), files=files)
 
 
-async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True):
+async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True) -> bytes:
     node = await fetch_node(conn=conn, node_id=1)
     assert node is not None
     assert node.event_node_id is not None

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -1,0 +1,235 @@
+from datetime import datetime, timedelta
+import pandas as pd
+import psycopg2 as psy
+from calendar import day_name
+
+from pydantic import BaseModel
+from sftkit.database import Connection
+
+from stustapay.bon.bon import BonConfig, gen_dummy_order
+from stustapay.core.currency import get_currency_symbol
+from stustapay.core.schema.media import Blob
+from stustapay.core.schema.order import Order
+from stustapay.core.schema.tree import Node, RestrictedEventSettings
+from stustapay.core.service.media import fetch_blob
+from stustapay.core.service.order.stats import (
+    Timeseries,
+    TimeseriesStatsQuery,
+    get_daily_stats,
+    get_event_time_bounds,
+    get_hourly_sales_stats,
+)
+from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
+from stustapay.reports.render import render_report
+
+
+class DailyRevenueLineBase(BaseModel):
+    order_type: str
+    payment_method: str
+    no_customers: float
+    no_products: float
+    total_price: float
+
+
+class DailyRevenueLineLocation(BaseModel):
+    order_type: str
+    node_name: str
+    payment_method: str
+    no_customers: float
+    no_products: float
+    total_price: float
+
+
+class DailyReportContext(BaseModel):
+    event_name: str
+    render_logo: bool
+    config: BonConfig
+    lines_base: list[DailyRevenueLineBase]
+    lines_location: list[DailyRevenueLineLocation]
+    from_time: datetime
+    to_time: datetime
+    currency_symbol: str
+
+
+async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
+
+    #TODO: Make query work
+    query_string = """
+            select o.id as order_id, uuid, item_count, booked_at, payment_method, o.z_nr, order_type, cancels_order, cashier_id, o.cash_register_id, till_id, o.customer_account_id, item_id, product_id, product_price, quantity, tax_name, tax_rate, total_price, total_tax, t.name as till_name, t.node_id as till_node_id, p.name as product_name, price_in_vouchers, u.login as cashier_login, u.display_name as cashier_name
+            from order_items o
+            left join till t on o.till_id = t.id
+            left join product p on o.product_id = p.id
+            left join usr u on o.cashier_id = u.id
+        """
+    conn_ = psy.connect(**conn)
+    data_all = pd.read_sql_query(query_string, conn_)
+
+    # get weekday (everything before 7AM counts to previous day)
+    data_all["weekday"] = data_all["booked_at_cest"].dt.dayofweek
+    data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "weekday"] -= 1
+    data_all["weekday"] = data_all["weekday"].apply(lambda x: day_name[int(x)])
+    data_all["date"] = data_all["booked_at_cest"].dt.normalize()
+    if day_starts_at_7:
+        data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "date"] -= timedelta(days=1)
+    data_all["date"] = data_all["date"].dt.date
+
+    # remove canceled sales
+    canceled_orders = pd.unique(data_all[data_all["order_type"] == "cancel_sale"]["cancels_order"])
+    data_all = data_all[~(data_all.index.isin(canceled_orders))]
+    data_all = data_all[data_all["order_type"] != "cancel_sale"]
+
+    all_relevant_transactions = data_all[
+        data_all["order_type"].isin(["sale", "ticket", "top_up", "pay_out", "money_transfer_imbalance"])].copy()
+
+    #TODO: How to add location categories?
+    locations_internal = list(ut.location_color_palette_internal.keys())
+    locations_external = list(ut.external_dict.keys())
+
+    all_relevant_transactions["sale_type"] = ""
+    all_relevant_transactions.loc[
+        all_relevant_transactions["node_name"].isin(locations_internal), "sale_type"] = "Verkauf interne Stände"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["node_name"].isin(locations_external), "sale_type"] = "Verkauf externe Stände"
+    all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "ticket", "sale_type"] = "Eintrittsticket"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["order_type"] == "top_up", "sale_type"] = "Aufladung Guthaben"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["order_type"] == "pay_out", "sale_type"] = "Auszahlung Guthaben"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["order_type"] == "money_transfer_imbalance", "sale_type"] = "Fehlbetrag Barkassen"
+    all_relevant_transactions.loc[all_relevant_transactions["sale_type"] == "", "sale_type"] = "Verkauf interne Stände"
+
+    return all_relevant_transactions
+
+
+async def make_daily_table(all_transactions: pd.DataFrame, date: str, break_down_locations: bool = False, break_down_products: bool = False,
+                     break_down_payment_methods: bool = False) -> (pd.DataFrame, datetime.date):
+    date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+    day_transactions = all_transactions[all_transactions["date"] == date_obj].reset_index()
+
+    group_by = ["sale_type"]
+    index_names = ["Art"]
+    if break_down_locations:
+        group_by.append("node_name")
+        index_names.append("Stand/Ort")
+    if break_down_products:
+        group_by.append("product_name")
+        index_names.append("Produkt")
+    if break_down_payment_methods:
+        group_by.append("payment_method")
+        index_names.append("Zahlung")
+
+    daily_table = day_transactions.groupby(group_by).agg({
+        "order_id": pd.Series.nunique,
+        "quantity": lambda x: int(sum(x)),
+        "total_price": lambda x: sum(x)
+    })
+    daily_table.columns = ["Kunden", "Produkte", "Summe"]
+    daily_table.index.set_names(index_names, inplace=True)
+
+    return daily_table, date_obj
+
+
+async def generate_dummy_daily_report(day: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
+    """Generate a dummy bon for the given event and return the pdf as bytes"""
+    fee = 0.01
+
+    ctx = DailyReportContext(
+        event_name=event.name,
+        render_logo=logo is not None,
+        config=BonConfig(
+            title=event.bon_title,
+            issuer=event.bon_issuer,
+            address=event.bon_address,
+            ust_id=event.ust_id,
+        ),
+        orders=[
+            OrderWithFees(
+                **dummy_order.model_dump(),
+                fees=dummy_order.total_price * fee,
+                total_price_minus_fees=dummy_order.total_price - dummy_order.total_price * fee,
+            )
+            for dummy_order in dummy_orders
+        ],
+        daily_revenue_stats=[
+            DailyRevenue(
+                day="Monday 2024-10-10",
+                revenue=10212,
+                fees=10212 * fee,
+                revenue_minus_fees=10212 - 10212 * fee,
+            ),
+            DailyRevenue(
+                day="Tuesday 2024-10-11",
+                revenue=3000.23,
+                fees=3000.23 * fee,
+                revenue_minus_fees=3000.23 - 3000.23 * fee,
+            ),
+        ],
+        from_time=datetime.now() - timedelta(days=3),
+        to_time=datetime.now(),
+        total_revenue=13212.23,
+        fees=13212.23 * fee,
+        fees_percent=fee,
+        revenue_minus_fees=13212.23 - 13212.23 * fee,
+        currency_symbol=get_currency_symbol(event.currency_identifier),
+    )
+    files = {}
+    if logo:
+        files["logo.svg"] = logo
+    return await render_report(template="report", template_context=ctx.model_dump(), files=files)
+
+
+async def generate_daily_report(conn: Connection, date: str, save_location: str = "", day_starts_at_7: bool = True):
+    node = await fetch_node(conn=conn, node_id=1)
+    assert node is not None
+    assert node.event_node_id is not None
+    event = await fetch_event_for_node(conn=conn, node=node)
+
+    all_relevant_transactions = await prep_all_data(conn=conn, day_starts_at_7=day_starts_at_7)
+
+    daily_base_table, date_obj = await make_daily_table(
+        all_relevant_transactions,
+        date,
+        break_down_locations=False,
+        break_down_products=False,
+        break_down_payment_methods=True
+    )
+
+    daily_location_table, _ = await make_daily_table(
+        all_relevant_transactions,
+        date,
+        break_down_locations=True,
+        break_down_products=False,
+        break_down_payment_methods=True
+    )
+
+    if day_starts_at_7:
+        from_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(hours=7)
+        to_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(days=1, hours=7)
+    else:
+        from_time = date_obj
+        to_time = date_obj + timedelta(days=1)
+
+    config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
+
+    event_design = await fetch_event_design(conn=conn, node_id=node.event_node_id)
+    logo = None
+    if event_design.bon_logo_blob_id is not None:
+        logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
+
+    context = DailyReportContext(
+        event_name=event.node_name,
+        render_logo=logo is not None,
+        config=config,
+        lines_base=None,
+        lines_location=None,
+        from_time=from_time,
+        to_time=to_time,
+        currency_symbol=get_currency_symbol(event.currency_identifier),
+    )
+    files = {}
+    if logo:
+        files["logo.svg"] = logo
+
+    #TODO: Specify save location
+    return await render_report(template="daily_totals", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -24,7 +24,7 @@ class PayoutRunForReport(BaseModel):
 
 
 class RemainingBalances(BaseModel):
-    remaining_balances: float
+    remaining_balances: float | None = 0.
 
 
 class PayoutReportContext(BaseModel):
@@ -33,7 +33,7 @@ class PayoutReportContext(BaseModel):
     config: BonConfig
     date: datetime
     payouts: list[PayoutRunForReport]
-    remaining_balances: float
+    remaining_balances: RemainingBalances
     currency_symbol: str
 
 
@@ -47,7 +47,7 @@ async def generate_payout_report(conn: Connection, year: int) -> bytes:
     payouts = await conn.fetch_many(PayoutRunForReport, query_string)
 
     #TODO: Is node id 1 always correct?
-    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1 as bigint) AND type='private';"
+    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1000 as bigint) AND type='private'"
     remaining_balances = await conn.fetch_one(RemainingBalances, remaining_balance_query)
 
     config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
@@ -71,4 +71,4 @@ async def generate_payout_report(conn: Connection, year: int) -> bytes:
         files["logo.svg"] = logo
 
     # TODO: Specify save location
-    return await render_report(template="payout_report", template_context=context.model_dump(), files=files)
+    return await render_report(template="payouts", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -1,0 +1,74 @@
+from calendar import day_name
+from datetime import datetime, timedelta
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel
+from sftkit.database import Connection
+
+from stustapay.bon.bon import BonConfig
+from stustapay.core.currency import get_currency_symbol
+from stustapay.core.schema.media import Blob
+from stustapay.core.schema.tree import RestrictedEventSettings
+from stustapay.core.service.media import fetch_blob
+from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
+from stustapay.reports.render import render_report
+
+
+class PayoutRunForReport(BaseModel):
+    set_done_at: datetime
+    n_payouts: int
+    total_payout_amount: float
+    total_donation_amount: float
+
+
+class RemainingBalances(BaseModel):
+    remaining_balances: float
+
+
+class PayoutReportContext(BaseModel):
+    event_name: str
+    render_logo: bool
+    config: BonConfig
+    date: datetime
+    payouts: list[PayoutRunForReport]
+    remaining_balances: float
+    currency_symbol: str
+
+
+async def generate_payout_report(conn: Connection, year: int) -> bytes:
+    node = await fetch_node(conn=conn, node_id=1)
+    assert node is not None
+    assert node.event_node_id is not None
+    event = await fetch_event_for_node(conn=conn, node=node)
+
+    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at;"
+    payouts = await conn.fetch_many(PayoutRunForReport, query_string)
+
+    #TODO: Is node id 1 always correct?
+    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1 as bigint) AND type='private';"
+    remaining_balances = await conn.fetch_one(RemainingBalances, remaining_balance_query)
+
+    config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
+
+    event_design = await fetch_event_design(conn=conn, node_id=node.event_node_id)
+    logo = None
+    if event_design.bon_logo_blob_id is not None:
+        logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
+
+    context = PayoutReportContext(
+        event_name=event.bon_title,
+        render_logo=logo is not None,
+        config=config,
+        date=datetime.today().date(),
+        payouts=payouts,
+        remaining_balances=remaining_balances,
+        currency_symbol=get_currency_symbol(event.currency_identifier),
+    )
+    files = {}
+    if logo:
+        files["logo.svg"] = logo
+
+    # TODO: Specify save location
+    return await render_report(template="payout_report", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -1,16 +1,9 @@
-from calendar import day_name
-from datetime import datetime, timedelta
-from typing import Optional
-
-import numpy as np
-import pandas as pd
+from datetime import datetime
 from pydantic import BaseModel
 from sftkit.database import Connection
 
 from stustapay.bon.bon import BonConfig
 from stustapay.core.currency import get_currency_symbol
-from stustapay.core.schema.media import Blob
-from stustapay.core.schema.tree import RestrictedEventSettings
 from stustapay.core.service.media import fetch_blob
 from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
 from stustapay.reports.render import render_report
@@ -43,7 +36,7 @@ async def generate_payout_report(conn: Connection, year: int) -> bytes:
     assert node.event_node_id is not None
     event = await fetch_event_for_node(conn=conn, node=node)
 
-    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at;"
+    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at"
     payouts = await conn.fetch_many(PayoutRunForReport, query_string)
 
     #TODO: Is node id 1 always correct?


### PR DESCRIPTION
Generate two new pdf reports:
- Daily revenues split by type of payment/payment method/node/...
- Overview over online payout runs and remaining balances of customers

Remaining Todos:
- Automatically split locations at first tree level instead of manual assignment via dictionary
- Better handling of shifted day breaks through event configuration
- Is the event parent node hardcoded as 1?
- Better formatting of reports (what happens if lines are too long? Do pagebreaks work? Vertical lines in table?)
- Integration into web UI