### PR TITLE
Revenue overviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ node_modules/
 
 # local
 TODO.md
+*.DS_Store
 
 # nix
 /.direnv

--- a/api/administration.json
+++ b/api/administration.json
@@ -7160,8 +7160,8 @@
         "tags": [
           "tree"
         ],
-        "summary": "Generate Test Report",
-        "operationId": "generate_test_report",
+        "summary": "Generate Test Revenue Report",
+        "operationId": "generate_test_revenue_report",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -7211,6 +7211,163 @@
         ],
         "summary": "Generate Revenue Report",
         "operationId": "generate_revenue_report",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Node Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "application/pdf": {}
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tree/nodes/{node_id}/generate-daily-report": {
+      "post": {
+        "tags": [
+          "tree"
+        ],
+        "summary": "Generate Daily Report",
+        "operationId": "generate_daily_report",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Node Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateDailyReportPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "application/pdf": {}
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tree/events/{node_id}/generate-test-daily-report": {
+      "post": {
+        "tags": [
+          "tree"
+        ],
+        "summary": "Generate Test Daily Report",
+        "operationId": "generate_test_daily_report",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Node Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "application/pdf": {}
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tree/nodes/{node_id}/generate-payout-report": {
+      "post": {
+        "tags": [
+          "tree"
+        ],
+        "summary": "Generate Payout Report",
+        "operationId": "generate_payout_report",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -9900,6 +10057,28 @@
           "search_term"
         ],
         "title": "FindUserTagPayload"
+      },
+      "GenerateDailyReportPayload": {
+        "properties": {
+          "relevant_node_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Relevant Node Ids"
+          },
+          "report_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Report Date"
+          }
+        },
+        "type": "object",
+        "required": [
+          "relevant_node_ids",
+          "report_date"
+        ],
+        "title": "GenerateDailyReportPayload"
       },
       "GenerateWebhookPayload": {
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "aiosmtplib==3.0.1",
     "weasyprint==65.0",
     "mako==1.3.9",
+    "pandas==2.2.3"
 ]
 
 [project.scripts]

--- a/stustapay/administration/routers/tree.py
+++ b/stustapay/administration/routers/tree.py
@@ -205,7 +205,7 @@ async def generate_test_daily_report(token: CurrentAuthToken, tree_service: Cont
     },
 )
 async def generate_payout_report(token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int):
-    content = await tree_service.generate_daily_report(token=token, node_id=node_id)
+    content = await tree_service.generate_payout_report(token=token, node_id=node_id)
     headers = {"Content-Disposition": 'inline; filename="payout_report.pdf"'}
     return Response(content, headers=headers, media_type="application/pdf")
 

--- a/stustapay/administration/routers/tree.py
+++ b/stustapay/administration/routers/tree.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
@@ -133,9 +135,9 @@ async def generate_webhook_url(
         }
     },
 )
-async def generate_test_report(token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int):
-    content = await tree_service.generate_test_report(token=token, node_id=node_id)
-    headers = {"Content-Disposition": 'inline; filename="test_report.pdf"'}
+async def generate_test_revenue_report(token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int):
+    content = await tree_service.generate_test_revenue_report(token=token, node_id=node_id)
+    headers = {"Content-Disposition": 'inline; filename="test_revenue_report.pdf"'}
     return Response(content, headers=headers, media_type="application/pdf")
 
 
@@ -151,6 +153,60 @@ async def generate_test_report(token: CurrentAuthToken, tree_service: ContextTre
 async def generate_revenue_report(token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int):
     content = await tree_service.generate_revenue_report(token=token, node_id=node_id)
     headers = {"Content-Disposition": 'inline; filename="revenue_report.pdf"'}
+    return Response(content, headers=headers, media_type="application/pdf")
+
+
+class GenerateDailyReportPayload(BaseModel):
+    relevant_node_ids: list[int]
+    report_date: date
+
+
+@router.post(
+    "/nodes/{node_id}/generate-daily-report",
+    responses={
+        "200": {
+            "description": "Successful Response",
+            "content": {"application/pdf": {}},
+        }
+    },
+)
+async def generate_daily_report(
+    token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int, payload: GenerateDailyReportPayload
+):
+    content = await tree_service.generate_daily_report(
+        token=token, node_id=node_id, relevant_node_ids=payload.relevant_node_ids, report_date=payload.report_date
+    )
+    headers = {"Content-Disposition": 'inline; filename="daily_report.pdf"'}
+    return Response(content, headers=headers, media_type="application/pdf")
+
+
+@router.post(
+    "/events/{node_id}/generate-test-daily-report",
+    responses={
+        "200": {
+            "description": "Successful Response",
+            "content": {"application/pdf": {}},
+        }
+    },
+)
+async def generate_test_daily_report(token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int):
+    content = await tree_service.generate_test_daily_report(token=token, node_id=node_id)
+    headers = {"Content-Disposition": 'inline; filename="test_daily_report.pdf"'}
+    return Response(content, headers=headers, media_type="application/pdf")
+
+
+@router.post(
+    "/nodes/{node_id}/generate-payout-report",
+    responses={
+        "200": {
+            "description": "Successful Response",
+            "content": {"application/pdf": {}},
+        }
+    },
+)
+async def generate_payout_report(token: CurrentAuthToken, tree_service: ContextTreeService, node_id: int):
+    content = await tree_service.generate_daily_report(token=token, node_id=node_id)
+    headers = {"Content-Disposition": 'inline; filename="payout_report.pdf"'}
     return Response(content, headers=headers, media_type="application/pdf")
 
 

--- a/stustapay/core/service/tree/common.py
+++ b/stustapay/core/service/tree/common.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 from sftkit.database import Connection
 
-from stustapay.core.schema.media import EventDesign
+from stustapay.core.schema.media import Blob, EventDesign
 from stustapay.core.schema.tree import (
     Language,
     Node,
@@ -11,6 +11,7 @@ from stustapay.core.schema.tree import (
 )
 from stustapay.core.schema.user import CurrentUser
 from stustapay.core.service.common.error import NotFound
+from stustapay.core.service.media import fetch_blob
 
 
 class TranslationText(BaseModel):
@@ -138,3 +139,10 @@ async def fetch_event_design(conn: Connection, node_id: int) -> EventDesign:
     if design is None:
         return EventDesign(bon_logo_blob_id=None)
     return design
+
+
+async def fetch_event_logo(conn: Connection, node_id: int) -> Blob | None:
+    event_design = await fetch_event_design(conn=conn, node_id=node_id)
+    if event_design.bon_logo_blob_id is not None:
+        return await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
+    return None

--- a/stustapay/core/service/tree/service.py
+++ b/stustapay/core/service/tree/service.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import asyncpg
 from sftkit.database import Connection
 from sftkit.service import Service, with_db_transaction
@@ -19,15 +21,18 @@ from stustapay.core.service.auth import AuthService
 from stustapay.core.service.common.audit_logs import create_audit_log, fetch_audit_logs
 from stustapay.core.service.common.decorators import requires_node, requires_user
 from stustapay.core.service.common.error import InvalidArgument, NotFound
-from stustapay.core.service.media import delete_blob, fetch_blob, store_blob
+from stustapay.core.service.media import delete_blob, store_blob
 from stustapay.core.service.tree.common import (
     fetch_event_design,
+    fetch_event_logo,
     fetch_node,
     fetch_restricted_event_settings_for_node,
     get_tree_for_current_user,
 )
 from stustapay.payment.sumup.api import fetch_refresh_token_from_auth_code
-from stustapay.reports.revenue_report import generate_dummy_report, generate_report
+from stustapay.reports.daily_reports import generate_daily_report, generate_dummy_daily_report
+from stustapay.reports.payout_report import generate_payout_report
+from stustapay.reports.revenue_report import generate_dummy_report, generate_revenue_report
 from stustapay.ticket_shop import pretix
 
 
@@ -454,31 +459,52 @@ class TreeService(Service[Config]):
     @requires_node(event_only=True)
     @requires_user(privileges=[Privilege.node_administration])
     async def check_pretix_connection(self, *, conn: Connection, node: Node) -> BonJson:
-        assert node.event_node_id is not None
         event = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node.id)
         return await pretix.check_connection(event)
 
     @with_db_transaction(read_only=True)
     @requires_node(event_only=True)
     @requires_user(privileges=[Privilege.node_administration])
-    async def generate_test_report(self, *, conn: Connection, node: Node) -> bytes:
-        assert node.event_node_id is not None
+    async def generate_test_revenue_report(self, *, conn: Connection, node: Node) -> bytes:
         event = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node.id)
-        event_design = await fetch_event_design(conn=conn, node_id=node.id)
-        logo = None
-        if event_design.bon_logo_blob_id is not None:
-            logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
-        content = await generate_dummy_report(node=node, event=event, logo=logo)
-        return content
+        logo = await fetch_event_logo(conn=conn, node_id=node.id)
+        return await generate_dummy_report(node=node, event=event, logo=logo)
 
     @with_db_transaction(read_only=True)
-    @requires_node()
+    @requires_node(event_only=True)
     @requires_user(privileges=[Privilege.node_administration])
     async def generate_revenue_report(self, *, conn: Connection, node: Node) -> bytes:
-        if node.event_node_id is None:
-            raise InvalidArgument("Cannot generate test report for a node not associated with an event")
-        content = await generate_report(conn=conn, node_id=node.id)
-        return content
+        return await generate_revenue_report(conn=conn, node=node)
+
+    @with_db_transaction(read_only=True)
+    @requires_node(event_only=True)
+    @requires_user(privileges=[Privilege.node_administration])
+    async def generate_test_daily_report(self, *, conn: Connection, node: Node) -> bytes:
+        event = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node.id)
+        logo = await fetch_event_logo(conn=conn, node_id=node.id)
+        return await generate_dummy_daily_report(node=node, event=event, logo=logo)
+
+    @with_db_transaction(read_only=True)
+    @requires_node(event_only=True)
+    @requires_user(privileges=[Privilege.node_administration])
+    async def generate_daily_report(
+        self, *, conn: Connection, node: Node, relevant_node_ids: list[int], report_date: date
+    ) -> bytes:
+        relevant_nodes: list[Node] = []
+        for relevant_node_id in relevant_node_ids:
+            rel_node = await fetch_node(conn=conn, node_id=relevant_node_id)
+            if rel_node is None:
+                raise InvalidArgument("Invalid node id")
+            if node.id not in rel_node.ids_to_root:
+                raise InvalidArgument("Invalid node id")
+            relevant_nodes.append(rel_node)
+        return await generate_daily_report(conn=conn, node=node, relevant_nodes=relevant_nodes, report_date=report_date)
+
+    @with_db_transaction(read_only=True)
+    @requires_node(event_only=True)
+    @requires_user(privileges=[Privilege.node_administration])
+    async def generate_payout_report(self, *, conn: Connection, node: Node) -> bytes:
+        return await generate_payout_report(conn=conn, node=node)
 
     @with_db_transaction
     @requires_node(event_only=True)

--- a/stustapay/core/service/tree/service.py
+++ b/stustapay/core/service/tree/service.py
@@ -482,7 +482,7 @@ class TreeService(Service[Config]):
     async def generate_test_daily_report(self, *, conn: Connection, node: Node) -> bytes:
         event = await fetch_restricted_event_settings_for_node(conn=conn, node_id=node.id)
         logo = await fetch_event_logo(conn=conn, node_id=node.id)
-        return await generate_dummy_daily_report(node=node, event=event, logo=logo)
+        return await generate_dummy_daily_report(event=event, logo=logo)
 
     @with_db_transaction(read_only=True)
     @requires_node(event_only=True)

--- a/stustapay/reports/assets/daily_totals.css
+++ b/stustapay/reports/assets/daily_totals.css
@@ -89,7 +89,8 @@ aside address#to {
 }
 
 .daily-revenue-table {
-    width: 100%
+    width: 100%;
+    font-size: 12px;
 }
 
 .table-header  {

--- a/stustapay/reports/assets/daily_totals.css
+++ b/stustapay/reports/assets/daily_totals.css
@@ -1,0 +1,101 @@
+* {
+    font-family: sans-serif;
+}
+
+@page {
+    margin: 15mm 0;
+    size: A4;
+
+    @bottom-center {
+        content: counter(page);
+        height: 1cm;
+        text-align: center;
+        width: 1cm;
+    }
+}
+
+@page :first {
+    margin: 0;
+}
+
+body {
+    margin: 0;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+.centered  {
+    text-align: center;
+}
+
+article {
+    margin: 15mm;
+    break-before: always;
+}
+article:first-of-type {
+    break-before: avoid;
+}
+
+#logo {
+    width: 100%;
+    height: 100px;
+    background: no-repeat top left / 200% url('logo.svg');
+}
+
+#header {
+    width: 100%;
+    font-weight: 400;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+#header-name {
+    font-size: 20px;
+}
+#header-title {
+    font-size: 30px;
+}
+#header-event {
+    font-size: 20px;
+}
+
+aside {
+    display: grid;
+    grid: auto auto;
+}
+aside address {
+    font-style: normal;
+    white-space: pre-line;
+}
+aside address#from {
+    grid-column: 1;
+    grid-row: 2;
+    text-align: left;
+}
+aside address#to {
+    grid-column: 2;
+    grid-row: 1;
+    text-align: right;
+}
+
+.overview-table {
+    width: 100%;
+}
+
+#daily-overview {
+    text-align: center;
+}
+
+.daily-revenue-table {
+    width: 100%
+}
+
+.table-header  {
+    border-bottom: 1px solid black;
+}
+
+.transaction-table {
+    width: 100%
+}

--- a/stustapay/reports/assets/daily_totals.html.mako
+++ b/stustapay/reports/assets/daily_totals.html.mako
@@ -1,0 +1,106 @@
+<%
+def format_money(value):
+  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
+
+def format_datetime(value):
+  return value.strftime("%Y-%m-%d %H:%M:%S")
+
+def format_percent(value):
+  return f"{value * 100:5.2f}%".replace(".", ",")
+
+%>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Revenue Report</title>
+    <meta name="description" content="Invoice demo sample">
+  </head>
+
+  <body>
+    % if render_logo:
+      <header id="logo">
+      </header>
+    % endif
+
+    <article>
+
+      <div id="header">
+        <span id="header-name">StuStaPay</span>
+        <span id="header-title">Umsatzbericht</span>
+        <span id="header-event">${event_name}</span>
+      </div>
+
+      <div id="overview">
+        <h3 class="centered">Gesamtübersicht</h3>
+        <table class="overview-table">
+          <tbody>
+            <tr>
+              <td>Beginn</td>
+              <td>${format_datetime(from_time)}</td>
+            </tr>
+            <tr>
+              <td>Letzer berücksichtigter Zeitpunkt</td>
+              <td>${format_datetime(to_time)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div id="base-table">
+        <h3 class="centered">Nach Transaktionsart</h3>
+        <table class="daily-revenue-table">
+          <thead>
+            <tr class="table-header">
+              <th>Art</th>
+              <th>Zahlung</th>
+              <th>Kunden</th>
+              <th>Proukte</th>
+              <th>Summe</th>
+            </tr>
+          </thead>
+          <tbody>
+            % for line in lines_base:
+            <tr>
+              <td>${line["order_type"]}</td>
+              <td>${line["payment_method"]}</td>
+              <td>${line["no_customers"]}</td>
+              <td>${line["no_products"]}</td>
+              <td>${format_money(daily["total_price"])}</td>
+            </tr>
+            % endfor
+          </tbody>
+        </table>
+      </div>
+
+      <div id="location-table">
+        <h3 class="centered">Nach Stand/Ort</h3>
+        <table class="daily-revenue-table">
+          <thead>
+            <tr class="table-header">
+              <th>Art</th>
+              <th>Stand/Ort</th>
+              <th>Zahlung</th>
+              <th>Kunden</th>
+              <th>Proukte</th>
+              <th>Summe</th>
+            </tr>
+          </thead>
+          <tbody>
+            % for line in lines_location:
+            <tr>
+              <td>${line["order_type"]}</td>
+              <td>${line["node_name"]}</td>
+              <td>${line["payment_method"]}</td>
+              <td>${line["no_customers"]}</td>
+              <td>${line["no_products"]}</td>
+              <td>${format_money(daily["total_price"])}</td>
+            </tr>
+            % endfor
+          </tbody>
+        </table>
+      </div>
+    </article>
+
+  </body>
+</html>

--- a/stustapay/reports/assets/daily_totals.html.mako
+++ b/stustapay/reports/assets/daily_totals.html.mako
@@ -1,15 +1,3 @@
-<%
-def format_money(value):
-  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
-
-def format_datetime(value):
-  return value.strftime("%Y-%m-%d %H:%M:%S")
-
-def format_percent(value):
-  return f"{value * 100:5.2f}%".replace(".", ",")
-
-%>
-
 <html>
   <head>
     <meta charset="utf-8">
@@ -46,33 +34,6 @@ def format_percent(value):
           </tbody>
         </table>
       </div>
-
-      <div id="base-table">
-        <h3 class="centered">Nach Transaktionsart</h3>
-        <table class="daily-revenue-table">
-          <thead>
-            <tr class="table-header">
-              <th>Art</th>
-              <th>Zahlung</th>
-              <th>Kunden</th>
-              <th>Produkte</th>
-              <th>Summe</th>
-            </tr>
-          </thead>
-          <tbody>
-            % for line in lines_base:
-            <tr>
-              <td>${line["order_type"]}</td>
-              <td>${line["payment_method"]}</td>
-              <td>${line["no_customers"]}</td>
-              <td>${line["no_products"]}</td>
-              <td>${format_money(line["total_price"])}</td>
-            </tr>
-            % endfor
-          </tbody>
-        </table>
-      </div>
-    </article>
 
     <article>
       <div id="location-table">

--- a/stustapay/reports/assets/daily_totals.html.mako
+++ b/stustapay/reports/assets/daily_totals.html.mako
@@ -28,14 +28,21 @@
               <td>${format_datetime(from_time)}</td>
             </tr>
             <tr>
+              <td>Erste Transaktions-ID</td>
+              <td>${"-" if min_order_id is None else min_order_id}</td>
+            </tr>
+            <tr>
               <td>Letzer berücksichtigter Zeitpunkt</td>
               <td>${format_datetime(to_time)}</td>
+            </tr>
+            <tr>
+              <td>Letzte Transaktions-ID</td>
+              <td>${"-" if max_order_id is None else max_order_id}</td>
             </tr>
           </tbody>
         </table>
       </div>
 
-    <article>
       <div id="location-table">
         <h3 class="centered">Nach Stand/Ort</h3>
         <table class="daily-revenue-table">
@@ -44,7 +51,7 @@
               <th>Art</th>
               <th>Stand/Ort</th>
               <th>Zahlung</th>
-              <th>Kunden</th>
+              <th>Transaktionen</th>
               <th>Produkte</th>
               <th>Summe</th>
             </tr>
@@ -64,6 +71,5 @@
         </table>
       </div>
     </article>
-
   </body>
 </html>

--- a/stustapay/reports/assets/daily_totals.html.mako
+++ b/stustapay/reports/assets/daily_totals.html.mako
@@ -55,7 +55,7 @@ def format_percent(value):
               <th>Art</th>
               <th>Zahlung</th>
               <th>Kunden</th>
-              <th>Proukte</th>
+              <th>Produkte</th>
               <th>Summe</th>
             </tr>
           </thead>
@@ -66,13 +66,15 @@ def format_percent(value):
               <td>${line["payment_method"]}</td>
               <td>${line["no_customers"]}</td>
               <td>${line["no_products"]}</td>
-              <td>${format_money(daily["total_price"])}</td>
+              <td>${format_money(line["total_price"])}</td>
             </tr>
             % endfor
           </tbody>
         </table>
       </div>
+    </article>
 
+    <article>
       <div id="location-table">
         <h3 class="centered">Nach Stand/Ort</h3>
         <table class="daily-revenue-table">
@@ -82,7 +84,7 @@ def format_percent(value):
               <th>Stand/Ort</th>
               <th>Zahlung</th>
               <th>Kunden</th>
-              <th>Proukte</th>
+              <th>Produkte</th>
               <th>Summe</th>
             </tr>
           </thead>
@@ -94,7 +96,7 @@ def format_percent(value):
               <td>${line["payment_method"]}</td>
               <td>${line["no_customers"]}</td>
               <td>${line["no_products"]}</td>
-              <td>${format_money(daily["total_price"])}</td>
+              <td>${format_money(line["total_price"])}</td>
             </tr>
             % endfor
           </tbody>

--- a/stustapay/reports/assets/payouts.css
+++ b/stustapay/reports/assets/payouts.css
@@ -89,7 +89,8 @@ aside address#to {
 }
 
 .daily-revenue-table {
-    width: 100%
+    width: 100%;
+    font-size: 12px;
 }
 
 .table-header  {

--- a/stustapay/reports/assets/payouts.css
+++ b/stustapay/reports/assets/payouts.css
@@ -1,0 +1,101 @@
+* {
+    font-family: sans-serif;
+}
+
+@page {
+    margin: 15mm 0;
+    size: A4;
+
+    @bottom-center {
+        content: counter(page);
+        height: 1cm;
+        text-align: center;
+        width: 1cm;
+    }
+}
+
+@page :first {
+    margin: 0;
+}
+
+body {
+    margin: 0;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+.centered  {
+    text-align: center;
+}
+
+article {
+    margin: 15mm;
+    break-before: always;
+}
+article:first-of-type {
+    break-before: avoid;
+}
+
+#logo {
+    width: 100%;
+    height: 100px;
+    background: no-repeat top left / 200% url('logo.svg');
+}
+
+#header {
+    width: 100%;
+    font-weight: 400;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+#header-name {
+    font-size: 20px;
+}
+#header-title {
+    font-size: 30px;
+}
+#header-event {
+    font-size: 20px;
+}
+
+aside {
+    display: grid;
+    grid: auto auto;
+}
+aside address {
+    font-style: normal;
+    white-space: pre-line;
+}
+aside address#from {
+    grid-column: 1;
+    grid-row: 2;
+    text-align: left;
+}
+aside address#to {
+    grid-column: 2;
+    grid-row: 1;
+    text-align: right;
+}
+
+.overview-table {
+    width: 100%;
+}
+
+#daily-overview {
+    text-align: center;
+}
+
+.daily-revenue-table {
+    width: 100%
+}
+
+.table-header  {
+    border-bottom: 1px solid black;
+}
+
+.transaction-table {
+    width: 100%
+}

--- a/stustapay/reports/assets/payouts.html.mako
+++ b/stustapay/reports/assets/payouts.html.mako
@@ -25,7 +25,11 @@
           <tbody>
             <tr>
               <td>Stand</td>
-              <td>${format_date(date)}</td>
+              <td>${format_datetime(date)}</td>
+            </tr>
+            <tr>
+              <td>Anzahl nicht zurückgeforderter Guthaben</td>
+              <td>${remaining_balances["remaining_customers"]}</td>
             </tr>
             <tr>
               <td>Summe übriger Guthaben</td>

--- a/stustapay/reports/assets/payouts.html.mako
+++ b/stustapay/reports/assets/payouts.html.mako
@@ -1,15 +1,3 @@
-<%
-def format_money(value):
-  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
-
-def format_date(value):
-  return value.strftime("%Y-%m-%d")
-
-def format_percent(value):
-  return f"{value * 100:5.2f}%".replace(".", ",")
-
-%>
-
 <html>
   <head>
     <meta charset="utf-8">

--- a/stustapay/reports/assets/payouts.html.mako
+++ b/stustapay/reports/assets/payouts.html.mako
@@ -41,7 +41,7 @@ def format_percent(value):
             </tr>
             <tr>
               <td>Summe übriger Guthaben</td>
-              <td>${format_money(remaining_balances)}</td>
+              <td>${format_money(remaining_balances["remaining_balances"])}</td>
             </tr>
           </tbody>
         </table>

--- a/stustapay/reports/assets/payouts.html.mako
+++ b/stustapay/reports/assets/payouts.html.mako
@@ -1,0 +1,76 @@
+<%
+def format_money(value):
+  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
+
+def format_date(value):
+  return value.strftime("%Y-%m-%d")
+
+def format_percent(value):
+  return f"{value * 100:5.2f}%".replace(".", ",")
+
+%>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Revenue Report</title>
+    <meta name="description" content="Invoice demo sample">
+  </head>
+
+  <body>
+    % if render_logo:
+      <header id="logo">
+      </header>
+    % endif
+
+    <article>
+
+      <div id="header">
+        <span id="header-name">StuStaPay</span>
+        <span id="header-title">Umsatzbericht</span>
+        <span id="header-event">${event_name}</span>
+      </div>
+
+      <div id="overview">
+        <h3 class="centered">Übersicht Online-Payouts</h3>
+        <table class="overview-table">
+          <tbody>
+            <tr>
+              <td>Stand</td>
+              <td>${format_date(date)}</td>
+            </tr>
+            <tr>
+              <td>Summe übriger Guthaben</td>
+              <td>${format_money(remaining_balances)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div id="base-table">
+        <h3 class="centered">Online-Auszahlungen</h3>
+        <table class="daily-revenue-table">
+          <thead>
+            <tr class="table-header">
+              <th>Ausgeführt am</th>
+              <th>Anzahl Auszahlungen</th>
+              <th>Summe Auszahlungen</th>
+              <th>Summe Spenden</th>
+            </tr>
+          </thead>
+          <tbody>
+            % for payout in payouts:
+            <tr>
+              <td>${format_date(payout["set_done_at"])}</td>
+              <td>${line["n_payouts"]}</td>
+              <td>${format_money(line["total_payout_amount"])}</td>
+              <td>${format_money(line["total_donation_amount"])}</td>
+            </tr>
+            % endfor
+          </tbody>
+        </table>
+      </div>
+    </article>
+
+  </body>
+</html>

--- a/stustapay/reports/assets/report.html.mako
+++ b/stustapay/reports/assets/report.html.mako
@@ -1,15 +1,3 @@
-<%
-def format_money(value):
-  return f"{value:8.2f}{currency_symbol}".replace(".", ",")
-
-def format_datetime(value):
-  return value.strftime("%Y-%m-%d %H:%M:%S")
-
-def format_percent(value):
-  return f"{value * 100:5.2f}%".replace(".", ",")
-
-%>
-
 <html>
   <head>
     <meta charset="utf-8">

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -1,24 +1,17 @@
-from datetime import datetime, timedelta
-import pandas as pd
-import psycopg2 as psy
 from calendar import day_name
+from datetime import datetime, timedelta
+from typing import Optional
 
+import numpy as np
+import pandas as pd
 from pydantic import BaseModel
 from sftkit.database import Connection
 
-from stustapay.bon.bon import BonConfig, gen_dummy_order
+from stustapay.bon.bon import BonConfig
 from stustapay.core.currency import get_currency_symbol
 from stustapay.core.schema.media import Blob
-from stustapay.core.schema.order import Order
-from stustapay.core.schema.tree import Node, RestrictedEventSettings
+from stustapay.core.schema.tree import RestrictedEventSettings
 from stustapay.core.service.media import fetch_blob
-from stustapay.core.service.order.stats import (
-    Timeseries,
-    TimeseriesStatsQuery,
-    get_daily_stats,
-    get_event_time_bounds,
-    get_hourly_sales_stats,
-)
 from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
 from stustapay.reports.render import render_report
 
@@ -26,8 +19,8 @@ from stustapay.reports.render import render_report
 class DailyRevenueLineBase(BaseModel):
     order_type: str
     payment_method: str
-    no_customers: float
-    no_products: float
+    no_customers: int
+    no_products: int
     total_price: float
 
 
@@ -35,8 +28,8 @@ class DailyRevenueLineLocation(BaseModel):
     order_type: str
     node_name: str
     payment_method: str
-    no_customers: float
-    no_products: float
+    no_customers: int
+    no_products: int
     total_price: float
 
 
@@ -51,26 +44,50 @@ class DailyReportContext(BaseModel):
     currency_symbol: str
 
 
-async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
+class OrderDaily(BaseModel):
+    order_id: int
+    booked_at: datetime
+    payment_method: str
+    order_type: str
+    cancels_order: Optional[int]
+    quantity: Optional[int]
+    total_price: Optional[float]
+    node_name: str
+    product_name: Optional[str]
 
-    #TODO: Make query work
+
+async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
     query_string = """
-            select o.id as order_id, uuid, item_count, booked_at, payment_method, o.z_nr, order_type, cancels_order, cashier_id, o.cash_register_id, till_id, o.customer_account_id, item_id, product_id, product_price, quantity, tax_name, tax_rate, total_price, total_tax, t.name as till_name, t.node_id as till_node_id, p.name as product_name, price_in_vouchers, u.login as cashier_login, u.display_name as cashier_name
-            from order_items o
-            left join till t on o.till_id = t.id
-            left join product p on o.product_id = p.id
-            left join usr u on o.cashier_id = u.id
-        """
-    conn_ = psy.connect(**conn)
-    data_all = pd.read_sql_query(query_string, conn_)
+        select o.id as order_id, booked_at, payment_method, order_type, cancels_order, quantity, total_price, n.name as node_name, p.name as product_name
+        from order_items o
+        left join till t on o.till_id = t.id
+        left join product p on o.product_id = p.id
+        left join usr u on o.cashier_id = u.id
+        left join node n on t.node_id = n.id
+    """
+    orders = await conn.fetch_many(OrderDaily, query_string)
+    data_all = pd.DataFrame(
+        {
+            "order_id": [line.order_id for line in orders],
+            "booked_at": [pd.to_datetime(line.booked_at) for line in orders],
+            "payment_method": [line.payment_method for line in orders],
+            "order_type": [line.order_type for line in orders],
+            "cancels_order": [line.cancels_order for line in orders],
+            "quantity": [line.quantity for line in orders],
+            "total_price": [line.total_price for line in orders],
+            "node_name": [line.node_name for line in orders],
+            "product_name": [line.product_name for line in orders],
+        }
+    )
 
     # get weekday (everything before 7AM counts to previous day)
-    data_all["weekday"] = data_all["booked_at_cest"].dt.dayofweek
-    data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "weekday"] -= 1
+    data_all["weekday"] = data_all["booked_at"].dt.dayofweek
+    data_all.loc[data_all["booked_at"].dt.hour < 7, "weekday"] -= 1
     data_all["weekday"] = data_all["weekday"].apply(lambda x: day_name[int(x)])
-    data_all["date"] = data_all["booked_at_cest"].dt.normalize()
+    data_all["date"] = data_all["booked_at"].dt.normalize()
+    # TODO: Get day start/end from tree
     if day_starts_at_7:
-        data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "date"] -= timedelta(days=1)
+        data_all.loc[data_all["booked_at"].dt.hour < 7, "date"] -= timedelta(days=1)
     data_all["date"] = data_all["date"].dt.date
 
     # remove canceled sales
@@ -79,63 +96,99 @@ async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.Da
     data_all = data_all[data_all["order_type"] != "cancel_sale"]
 
     all_relevant_transactions = data_all[
-        data_all["order_type"].isin(["sale", "ticket", "top_up", "pay_out", "money_transfer_imbalance"])].copy()
+        data_all["order_type"].isin(["sale", "ticket", "top_up", "pay_out", "money_transfer_imbalance"])
+    ].copy()
 
-    #TODO: How to add location categories?
-    locations_internal = list(ut.location_color_palette_internal.keys())
-    locations_external = list(ut.external_dict.keys())
+    # TODO: How to add location categories?
+    location_color_palette_internal = {
+        "Brotladen": "peru",
+        "Cocktailzelt": "darkorchid",
+        "Cubalounge": "red",
+        "Festzelt": "lightskyblue",
+        "Infozelt": "darkgrey",
+        "Kade": "gold",
+        "Weißbierkarussell": "darkgreen",
+        "MKH Ausschank": "darkred",
+        "Pfandkasse": "black",
+        "Potzelt": "darkorange",
+        "Tribühne": "darkred",
+        "Turniere": "palegreen",
+        "Weinzelt": "pink",
+        "Weißbierinsel": "mediumblue",
+        # 'StuStaCulum 2024': "orchid",
+    }
+
+    external_dict = {
+        "Sunny's Churros": "Sunny's Churros",
+        "Cheese & Beef": "Cheese & Beef",
+        "Mezze Kebap": "Mezze Kebap",
+        "Holzofendinnede Abt": "Holzofendinnede",
+        "Event Gastronomie Weiß": "Crepes",
+        "Kati’s Tolle Knolle": "Kati’s Tolle Knolle",
+        "Christian UG": "Fish & Chips",
+        "Der Zwerg": "Guaranawein",
+        "Ümit Patir": "Kartoffelchips",
+        "Ayur Aahar": "Indian Streetfood",
+        "Tobias Mörtl": "Kartoffelpuffer",
+        "Coni's Schwenkgrill": "Coni's Schwenkgrill",
+        "Kreitz": "Pizzabaguette",
+    }
+    locations_internal = list(location_color_palette_internal.keys())
+    locations_external = list(external_dict.keys())
 
     all_relevant_transactions["sale_type"] = ""
-    all_relevant_transactions.loc[
-        all_relevant_transactions["node_name"].isin(locations_internal), "sale_type"] = "Verkauf interne Stände"
-    all_relevant_transactions.loc[
-        all_relevant_transactions["node_name"].isin(locations_external), "sale_type"] = "Verkauf externe Stände"
+    all_relevant_transactions.loc[all_relevant_transactions["node_name"].isin(locations_internal), "sale_type"] = (
+        "Verkauf interne Stände"
+    )
+    all_relevant_transactions.loc[all_relevant_transactions["node_name"].isin(locations_external), "sale_type"] = (
+        "Verkauf externe Stände"
+    )
     all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "ticket", "sale_type"] = "Eintrittsticket"
+    all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "top_up", "sale_type"] = (
+        "Aufladung Guthaben"
+    )
+    all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "pay_out", "sale_type"] = (
+        "Auszahlung Guthaben"
+    )
     all_relevant_transactions.loc[
-        all_relevant_transactions["order_type"] == "top_up", "sale_type"] = "Aufladung Guthaben"
-    all_relevant_transactions.loc[
-        all_relevant_transactions["order_type"] == "pay_out", "sale_type"] = "Auszahlung Guthaben"
-    all_relevant_transactions.loc[
-        all_relevant_transactions["order_type"] == "money_transfer_imbalance", "sale_type"] = "Fehlbetrag Barkassen"
-    all_relevant_transactions.loc[all_relevant_transactions["sale_type"] == "", "sale_type"] = "Verkauf interne Stände"
+        all_relevant_transactions["order_type"] == "money_transfer_imbalance", "sale_type"
+    ] = "Fehlbetrag Barkassen"
+    all_relevant_transactions.loc[all_relevant_transactions["sale_type"] == "", "sale_type"] = "Sonstige"
 
     return all_relevant_transactions
 
 
-async def make_daily_table(all_transactions: pd.DataFrame, date: str, break_down_locations: bool = False, break_down_products: bool = False,
-                     break_down_payment_methods: bool = False) -> (pd.DataFrame, datetime.date):
+async def make_daily_table(
+    all_transactions: pd.DataFrame,
+    date: str,
+    break_down_locations: bool = False,
+    break_down_products: bool = False,
+    break_down_payment_methods: bool = False,
+) -> (pd.DataFrame, datetime.date):
     date_obj = datetime.strptime(date, "%Y-%m-%d").date()
     day_transactions = all_transactions[all_transactions["date"] == date_obj].reset_index()
 
     group_by = ["sale_type"]
-    index_names = ["Art"]
     if break_down_locations:
         group_by.append("node_name")
-        index_names.append("Stand/Ort")
     if break_down_products:
         group_by.append("product_name")
-        index_names.append("Produkt")
     if break_down_payment_methods:
         group_by.append("payment_method")
-        index_names.append("Zahlung")
 
-    daily_table = day_transactions.groupby(group_by).agg({
-        "order_id": pd.Series.nunique,
-        "quantity": lambda x: int(sum(x)),
-        "total_price": lambda x: sum(x)
-    })
-    daily_table.columns = ["Kunden", "Produkte", "Summe"]
-    daily_table.index.set_names(index_names, inplace=True)
+    daily_table = (
+        day_transactions.groupby(group_by)
+        .agg({"order_id": pd.Series.nunique, "quantity": lambda x: int(np.sum(x)), "total_price": lambda x: np.sum(x)})
+        .reset_index()
+    )
 
     return daily_table, date_obj
 
 
-async def generate_dummy_daily_report(day: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
+async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
     """Generate a dummy bon for the given event and return the pdf as bytes"""
-    fee = 0.01
-
     ctx = DailyReportContext(
-        event_name=event.name,
+        event_name=event.bon_title,
         render_logo=logo is not None,
         config=BonConfig(
             title=event.bon_title,
@@ -143,43 +196,89 @@ async def generate_dummy_daily_report(day: str, event: RestrictedEventSettings, 
             address=event.bon_address,
             ust_id=event.ust_id,
         ),
-        orders=[
-            OrderWithFees(
-                **dummy_order.model_dump(),
-                fees=dummy_order.total_price * fee,
-                total_price_minus_fees=dummy_order.total_price - dummy_order.total_price * fee,
-            )
-            for dummy_order in dummy_orders
-        ],
-        daily_revenue_stats=[
-            DailyRevenue(
-                day="Monday 2024-10-10",
-                revenue=10212,
-                fees=10212 * fee,
-                revenue_minus_fees=10212 - 10212 * fee,
-            ),
-            DailyRevenue(
-                day="Tuesday 2024-10-11",
-                revenue=3000.23,
-                fees=3000.23 * fee,
-                revenue_minus_fees=3000.23 - 3000.23 * fee,
-            ),
-        ],
         from_time=datetime.now() - timedelta(days=3),
         to_time=datetime.now(),
-        total_revenue=13212.23,
-        fees=13212.23 * fee,
-        fees_percent=fee,
-        revenue_minus_fees=13212.23 - 13212.23 * fee,
         currency_symbol=get_currency_symbol(event.currency_identifier),
+        lines_base=[
+            DailyRevenueLineBase(
+                order_type="Ticket",
+                payment_method="Bar",
+                no_customers=100,
+                no_products=120,
+                total_price=10 * 120,
+            ),
+            DailyRevenueLineBase(
+                order_type="Ticket",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=10 * 210,
+            ),
+            DailyRevenueLineBase(
+                order_type="Topup",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=17.67 * 210,
+            ),
+            DailyRevenueLineBase(
+                order_type="Sales",
+                payment_method="Tag",
+                no_customers=320,
+                no_products=470,
+                total_price=10475.74,
+            ),
+        ],
+        lines_location=[
+            DailyRevenueLineLocation(
+                order_type="Ticket",
+                node_name="EntryTopup",
+                payment_method="Bar",
+                no_customers=100,
+                no_products=120,
+                total_price=10 * 120,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Ticket",
+                node_name="EntryTopup",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=10 * 210,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Topup",
+                node_name="EntryTopup",
+                payment_method="Karte",
+                no_customers=200,
+                no_products=210,
+                total_price=17.67 * 210,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Sales",
+                node_name="Festzelt",
+                payment_method="Tag",
+                no_customers=200,
+                no_products=350,
+                total_price=10475.74 * 2 / 3,
+            ),
+            DailyRevenueLineLocation(
+                order_type="Sales",
+                node_name="WBI",
+                payment_method="Tag",
+                no_customers=120,
+                no_products=470,
+                total_price=10475.74 * 1 / 3,
+            ),
+        ],
     )
     files = {}
     if logo:
         files["logo.svg"] = logo
-    return await render_report(template="report", template_context=ctx.model_dump(), files=files)
+    return await render_report(template="daily_totals", template_context=ctx.model_dump(), files=files)
 
 
-async def generate_daily_report(conn: Connection, date: str, save_location: str = "", day_starts_at_7: bool = True):
+async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True):
     node = await fetch_node(conn=conn, node_id=1)
     assert node is not None
     assert node.event_node_id is not None
@@ -192,17 +291,41 @@ async def generate_daily_report(conn: Connection, date: str, save_location: str 
         date,
         break_down_locations=False,
         break_down_products=False,
-        break_down_payment_methods=True
+        break_down_payment_methods=True,
     )
+    lines_base_table = []
+    for line in daily_base_table.itertuples():
+        lines_base_table.append(
+            DailyRevenueLineBase(
+                order_type=line.sale_type,
+                payment_method=line.payment_method,
+                no_customers=line.order_id,
+                no_products=line.quantity,
+                total_price=line.total_price,
+            )
+        )
 
     daily_location_table, _ = await make_daily_table(
         all_relevant_transactions,
         date,
         break_down_locations=True,
         break_down_products=False,
-        break_down_payment_methods=True
+        break_down_payment_methods=True,
     )
+    lines_location_table = []
+    for line in daily_location_table.itertuples():
+        lines_location_table.append(
+            DailyRevenueLineLocation(
+                order_type=line.sale_type,
+                node_name=line.node_name,
+                payment_method=line.payment_method,
+                no_customers=line.order_id,
+                no_products=line.quantity,
+                total_price=line.total_price,
+            )
+        )
 
+    # TODO: Get day start/end from tree
     if day_starts_at_7:
         from_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(hours=7)
         to_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(days=1, hours=7)
@@ -218,11 +341,11 @@ async def generate_daily_report(conn: Connection, date: str, save_location: str 
         logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
 
     context = DailyReportContext(
-        event_name=event.node_name,
+        event_name=event.bon_title,
         render_logo=logo is not None,
         config=config,
-        lines_base=None,
-        lines_location=None,
+        lines_base=lines_base_table,
+        lines_location=lines_location_table,
         from_time=from_time,
         to_time=to_time,
         currency_symbol=get_currency_symbol(event.currency_identifier),
@@ -231,5 +354,5 @@ async def generate_daily_report(conn: Connection, date: str, save_location: str 
     if logo:
         files["logo.svg"] = logo
 
-    #TODO: Specify save location
+    # TODO: Specify save location
     return await render_report(template="daily_totals", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -1,5 +1,5 @@
 from calendar import day_name
-from datetime import datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Optional
 
 import numpy as np
@@ -10,18 +10,10 @@ from sftkit.database import Connection
 from stustapay.bon.bon import BonConfig
 from stustapay.core.currency import get_currency_symbol
 from stustapay.core.schema.media import Blob
-from stustapay.core.schema.tree import RestrictedEventSettings
+from stustapay.core.schema.tree import Node, RestrictedEventSettings
 from stustapay.core.service.media import fetch_blob
-from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
+from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node
 from stustapay.reports.render import render_report
-
-
-class DailyRevenueLineBase(BaseModel):
-    order_type: str
-    payment_method: str
-    no_customers: int
-    no_products: int
-    total_price: float
 
 
 class DailyRevenueLineLocation(BaseModel):
@@ -37,7 +29,6 @@ class DailyReportContext(BaseModel):
     event_name: str
     render_logo: bool
     config: BonConfig
-    lines_base: list[DailyRevenueLineBase]
     lines_location: list[DailyRevenueLineLocation]
     from_time: datetime
     to_time: datetime
@@ -56,7 +47,7 @@ class OrderDaily(BaseModel):
     product_name: Optional[str]
 
 
-async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
+async def prep_all_data(conn: Connection, daily_end_time: time) -> pd.DataFrame:
     query_string = """
         select o.id as order_id, booked_at, payment_method, order_type, cancels_order, quantity, total_price, n.name as node_name, p.name as product_name
         from order_items o
@@ -86,8 +77,7 @@ async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.Da
     data_all["weekday"] = data_all["weekday"].apply(lambda x: day_name[int(x)])
     data_all["date"] = data_all["booked_at"].dt.normalize()
     # TODO: Get day start/end from tree
-    if day_starts_at_7:
-        data_all.loc[data_all["booked_at"].dt.hour < 7, "date"] -= timedelta(days=1)
+    data_all.loc[data_all["booked_at"].dt.time < daily_end_time, "date"] -= timedelta(days=1)
     data_all["date"] = data_all["date"].dt.date
 
     # remove canceled sales
@@ -160,17 +150,17 @@ async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.Da
 
 async def make_daily_table(
     all_transactions: pd.DataFrame,
-    date: str,
-    break_down_locations: bool = False,
+    date: date,
+    relevant_nodes: list[Node],
     break_down_products: bool = False,
     break_down_payment_methods: bool = False,
-) -> (pd.DataFrame, datetime.date):
-    date_obj = datetime.strptime(date, "%Y-%m-%d").date()
-    day_transactions = all_transactions[all_transactions["date"] == date_obj].reset_index()
+) -> tuple[pd.DataFrame, date]:
+    day_transactions = all_transactions[all_transactions["date"] == date].reset_index()
 
     group_by = ["sale_type"]
-    if break_down_locations:
-        group_by.append("node_name")
+    # TODO
+    # if break_down_locations:
+    #     group_by.append("node_name")
     if break_down_products:
         group_by.append("product_name")
     if break_down_payment_methods:
@@ -182,10 +172,10 @@ async def make_daily_table(
         .reset_index()
     )
 
-    return daily_table, date_obj
+    return daily_table, date
 
 
-async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
+async def generate_dummy_daily_report(node: Node, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
     """Generate a dummy bon for the given event and return the pdf as bytes"""
     ctx = DailyReportContext(
         event_name=event.bon_title,
@@ -199,36 +189,6 @@ async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings,
         from_time=datetime.now() - timedelta(days=3),
         to_time=datetime.now(),
         currency_symbol=get_currency_symbol(event.currency_identifier),
-        lines_base=[
-            DailyRevenueLineBase(
-                order_type="Ticket",
-                payment_method="Bar",
-                no_customers=100,
-                no_products=120,
-                total_price=10 * 120,
-            ),
-            DailyRevenueLineBase(
-                order_type="Ticket",
-                payment_method="Karte",
-                no_customers=200,
-                no_products=210,
-                total_price=10 * 210,
-            ),
-            DailyRevenueLineBase(
-                order_type="Topup",
-                payment_method="Karte",
-                no_customers=200,
-                no_products=210,
-                total_price=17.67 * 210,
-            ),
-            DailyRevenueLineBase(
-                order_type="Sales",
-                payment_method="Tag",
-                no_customers=320,
-                no_products=470,
-                total_price=10475.74,
-            ),
-        ],
         lines_location=[
             DailyRevenueLineLocation(
                 order_type="Ticket",
@@ -278,37 +238,17 @@ async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings,
     return await render_report(template="daily_totals", template_context=ctx.model_dump(), files=files)
 
 
-async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True) -> bytes:
-    node = await fetch_node(conn=conn, node_id=1)
-    assert node is not None
-    assert node.event_node_id is not None
+async def generate_daily_report(conn: Connection, node: Node, report_date: date, relevant_nodes: list[Node]) -> bytes:
     event = await fetch_event_for_node(conn=conn, node=node)
+    assert event.daily_end_time is not None
+    assert node.event_node_id is not None
 
-    all_relevant_transactions = await prep_all_data(conn=conn, day_starts_at_7=day_starts_at_7)
-
-    daily_base_table, date_obj = await make_daily_table(
-        all_relevant_transactions,
-        date,
-        break_down_locations=False,
-        break_down_products=False,
-        break_down_payment_methods=True,
-    )
-    lines_base_table = []
-    for line in daily_base_table.itertuples():
-        lines_base_table.append(
-            DailyRevenueLineBase(
-                order_type=line.sale_type,
-                payment_method=line.payment_method,
-                no_customers=line.order_id,
-                no_products=line.quantity,
-                total_price=line.total_price,
-            )
-        )
+    all_relevant_transactions = await prep_all_data(conn=conn, daily_end_time=event.daily_end_time)
 
     daily_location_table, _ = await make_daily_table(
         all_relevant_transactions,
-        date,
-        break_down_locations=True,
+        report_date,
+        relevant_nodes=relevant_nodes,
         break_down_products=False,
         break_down_payment_methods=True,
     )
@@ -326,12 +266,8 @@ async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bo
         )
 
     # TODO: Get day start/end from tree
-    if day_starts_at_7:
-        from_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(hours=7)
-        to_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(days=1, hours=7)
-    else:
-        from_time = date_obj
-        to_time = date_obj + timedelta(days=1)
+    from_time = datetime.combine(report_date, datetime.min.time()) + timedelta(hours=7)
+    to_time = datetime.combine(report_date, datetime.min.time()) + timedelta(days=1, hours=7)
 
     config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
 
@@ -344,7 +280,6 @@ async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bo
         event_name=event.bon_title,
         render_logo=logo is not None,
         config=config,
-        lines_base=lines_base_table,
         lines_location=lines_location_table,
         from_time=from_time,
         to_time=to_time,

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -278,7 +278,7 @@ async def generate_dummy_daily_report(date: str, event: RestrictedEventSettings,
     return await render_report(template="daily_totals", template_context=ctx.model_dump(), files=files)
 
 
-async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True):
+async def generate_daily_report(conn: Connection, date: str, day_starts_at_7: bool = True) -> bytes:
     node = await fetch_node(conn=conn, node_id=1)
     assert node is not None
     assert node.event_node_id is not None

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -200,9 +200,9 @@ async def generate_daily_report(conn: Connection, node: Node, report_date: date,
     min_order_id = None
     max_order_id = None
 
-    for node in relevant_nodes:
+    for relevant_node in relevant_nodes:
         all_relevant_transactions = await prep_all_data(
-            conn=conn, daily_end_time=event.daily_end_time, relevant_node_id=node.id, relevant_date=report_date
+            conn=conn, daily_end_time=event.daily_end_time, relevant_node_id=relevant_node.id, relevant_date=report_date
         )
         daily_location_table = await make_daily_table(
             all_relevant_transactions,
@@ -223,7 +223,7 @@ async def generate_daily_report(conn: Connection, node: Node, report_date: date,
             )
             .reset_index()
         )
-        agg_location_table.loc[agg_location_table["sale_type"] == "Verkauf", "node_name"] = node.name
+        agg_location_table.loc[agg_location_table["sale_type"] == "Verkauf", "node_name"] = relevant_node.name
 
         for line in agg_location_table.itertuples():
             lines_location_table.append(

--- a/stustapay/reports/daily_reports.py
+++ b/stustapay/reports/daily_reports.py
@@ -1,0 +1,235 @@
+from datetime import datetime, timedelta
+import pandas as pd
+import psycopg2 as psy
+from calendar import day_name
+
+from pydantic import BaseModel
+from sftkit.database import Connection
+
+from stustapay.bon.bon import BonConfig, gen_dummy_order
+from stustapay.core.currency import get_currency_symbol
+from stustapay.core.schema.media import Blob
+from stustapay.core.schema.order import Order
+from stustapay.core.schema.tree import Node, RestrictedEventSettings
+from stustapay.core.service.media import fetch_blob
+from stustapay.core.service.order.stats import (
+    Timeseries,
+    TimeseriesStatsQuery,
+    get_daily_stats,
+    get_event_time_bounds,
+    get_hourly_sales_stats,
+)
+from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
+from stustapay.reports.render import render_report
+
+
+class DailyRevenueLineBase(BaseModel):
+    order_type: str
+    payment_method: str
+    no_customers: float
+    no_products: float
+    total_price: float
+
+
+class DailyRevenueLineLocation(BaseModel):
+    order_type: str
+    node_name: str
+    payment_method: str
+    no_customers: float
+    no_products: float
+    total_price: float
+
+
+class DailyReportContext(BaseModel):
+    event_name: str
+    render_logo: bool
+    config: BonConfig
+    lines_base: list[DailyRevenueLineBase]
+    lines_location: list[DailyRevenueLineLocation]
+    from_time: datetime
+    to_time: datetime
+    currency_symbol: str
+
+
+async def prep_all_data(conn: Connection, day_starts_at_7: bool = True) -> pd.DataFrame:
+
+    #TODO: Make query work
+    query_string = """
+            select o.id as order_id, uuid, item_count, booked_at, payment_method, o.z_nr, order_type, cancels_order, cashier_id, o.cash_register_id, till_id, o.customer_account_id, item_id, product_id, product_price, quantity, tax_name, tax_rate, total_price, total_tax, t.name as till_name, t.node_id as till_node_id, p.name as product_name, price_in_vouchers, u.login as cashier_login, u.display_name as cashier_name
+            from order_items o
+            left join till t on o.till_id = t.id
+            left join product p on o.product_id = p.id
+            left join usr u on o.cashier_id = u.id
+        """
+    conn_ = psy.connect(**conn)
+    data_all = pd.read_sql_query(query_string, conn_)
+
+    # get weekday (everything before 7AM counts to previous day)
+    data_all["weekday"] = data_all["booked_at_cest"].dt.dayofweek
+    data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "weekday"] -= 1
+    data_all["weekday"] = data_all["weekday"].apply(lambda x: day_name[int(x)])
+    data_all["date"] = data_all["booked_at_cest"].dt.normalize()
+    if day_starts_at_7:
+        data_all.loc[data_all["booked_at_cest"].dt.hour < 7, "date"] -= timedelta(days=1)
+    data_all["date"] = data_all["date"].dt.date
+
+    # remove canceled sales
+    canceled_orders = pd.unique(data_all[data_all["order_type"] == "cancel_sale"]["cancels_order"])
+    data_all = data_all[~(data_all.index.isin(canceled_orders))]
+    data_all = data_all[data_all["order_type"] != "cancel_sale"]
+
+    all_relevant_transactions = data_all[
+        data_all["order_type"].isin(["sale", "ticket", "top_up", "pay_out", "money_transfer_imbalance"])].copy()
+
+    #TODO: How to add location categories?
+    locations_internal = list(ut.location_color_palette_internal.keys())
+    locations_external = list(ut.external_dict.keys())
+
+    all_relevant_transactions["sale_type"] = ""
+    all_relevant_transactions.loc[
+        all_relevant_transactions["node_name"].isin(locations_internal), "sale_type"] = "Verkauf interne Stände"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["node_name"].isin(locations_external), "sale_type"] = "Verkauf externe Stände"
+    all_relevant_transactions.loc[all_relevant_transactions["order_type"] == "ticket", "sale_type"] = "Eintrittsticket"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["order_type"] == "top_up", "sale_type"] = "Aufladung Guthaben"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["order_type"] == "pay_out", "sale_type"] = "Auszahlung Guthaben"
+    all_relevant_transactions.loc[
+        all_relevant_transactions["order_type"] == "money_transfer_imbalance", "sale_type"] = "Fehlbetrag Barkassen"
+    all_relevant_transactions.loc[all_relevant_transactions["sale_type"] == "", "sale_type"] = "Verkauf interne Stände"
+
+    return all_relevant_transactions
+
+
+async def make_daily_table(all_transactions: pd.DataFrame, date: str, break_down_locations: bool = False, break_down_products: bool = False,
+                     break_down_payment_methods: bool = False) -> (pd.DataFrame, datetime.date):
+    date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+    day_transactions = all_transactions[all_transactions["date"] == date_obj].reset_index()
+
+    group_by = ["sale_type"]
+    index_names = ["Art"]
+    if break_down_locations:
+        group_by.append("node_name")
+        index_names.append("Stand/Ort")
+    if break_down_products:
+        group_by.append("product_name")
+        index_names.append("Produkt")
+    if break_down_payment_methods:
+        group_by.append("payment_method")
+        index_names.append("Zahlung")
+
+    daily_table = day_transactions.groupby(group_by).agg({
+        "order_id": pd.Series.nunique,
+        "quantity": lambda x: int(sum(x)),
+        "total_price": lambda x: sum(x)
+    })
+    daily_table.columns = ["Kunden", "Produkte", "Summe"]
+    daily_table.index.set_names(index_names, inplace=True)
+
+    return daily_table, date_obj
+
+
+async def generate_dummy_daily_report(day: str, event: RestrictedEventSettings, logo: Blob | None) -> bytes:
+    """Generate a dummy bon for the given event and return the pdf as bytes"""
+    fee = 0.01
+
+    ctx = DailyReportContext(
+        event_name=event.name,
+        render_logo=logo is not None,
+        config=BonConfig(
+            title=event.bon_title,
+            issuer=event.bon_issuer,
+            address=event.bon_address,
+            ust_id=event.ust_id,
+        ),
+        orders=[
+            OrderWithFees(
+                **dummy_order.model_dump(),
+                fees=dummy_order.total_price * fee,
+                total_price_minus_fees=dummy_order.total_price - dummy_order.total_price * fee,
+            )
+            for dummy_order in dummy_orders
+        ],
+        daily_revenue_stats=[
+            DailyRevenue(
+                day="Monday 2024-10-10",
+                revenue=10212,
+                fees=10212 * fee,
+                revenue_minus_fees=10212 - 10212 * fee,
+            ),
+            DailyRevenue(
+                day="Tuesday 2024-10-11",
+                revenue=3000.23,
+                fees=3000.23 * fee,
+                revenue_minus_fees=3000.23 - 3000.23 * fee,
+            ),
+        ],
+        from_time=datetime.now() - timedelta(days=3),
+        to_time=datetime.now(),
+        total_revenue=13212.23,
+        fees=13212.23 * fee,
+        fees_percent=fee,
+        revenue_minus_fees=13212.23 - 13212.23 * fee,
+        currency_symbol=get_currency_symbol(event.currency_identifier),
+    )
+    files = {}
+    if logo:
+        files["logo.svg"] = logo
+    return await render_report(template="report", template_context=ctx.model_dump(), files=files)
+
+
+async def generate_daily_report(conn: Connection, date: str, save_location: str = "", day_starts_at_7: bool = True):
+    node = await fetch_node(conn=conn, node_id=1)
+    assert node is not None
+    assert node.event_node_id is not None
+    event = await fetch_event_for_node(conn=conn, node=node)
+
+    all_relevant_transactions = await prep_all_data(conn=conn, day_starts_at_7=day_starts_at_7)
+
+    daily_base_table, date_obj = await make_daily_table(
+        all_relevant_transactions,
+        date,
+        break_down_locations=False,
+        break_down_products=False,
+        break_down_payment_methods=True
+    )
+
+    daily_location_table, _ = await make_daily_table(
+        all_relevant_transactions,
+        date,
+        break_down_locations=True,
+        break_down_products=False,
+        break_down_payment_methods=True
+    )
+
+    if day_starts_at_7:
+        from_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(hours=7)
+        to_time = datetime.combine(date_obj, datetime.min.time()) + timedelta(days=1, hours=7)
+    else:
+        from_time = date_obj
+        to_time = date_obj + timedelta(days=1)
+
+    config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
+
+    event_design = await fetch_event_design(conn=conn, node_id=node.event_node_id)
+    logo = None
+    if event_design.bon_logo_blob_id is not None:
+        logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
+
+    context = DailyReportContext(
+        event_name=event.node_name,
+        render_logo=logo is not None,
+        config=config,
+        lines_base=None,
+        lines_location=None,
+        from_time=from_time,
+        to_time=to_time,
+        currency_symbol=get_currency_symbol(event.currency_identifier),
+    )
+    files = {}
+    if logo:
+        files["logo.svg"] = logo
+
+    #TODO: Specify save location
+    return await render_report(template="daily_totals", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -24,7 +24,7 @@ class PayoutRunForReport(BaseModel):
 
 
 class RemainingBalances(BaseModel):
-    remaining_balances: float
+    remaining_balances: float | None = 0.
 
 
 class PayoutReportContext(BaseModel):
@@ -33,7 +33,7 @@ class PayoutReportContext(BaseModel):
     config: BonConfig
     date: datetime
     payouts: list[PayoutRunForReport]
-    remaining_balances: float
+    remaining_balances: RemainingBalances
     currency_symbol: str
 
 
@@ -47,7 +47,7 @@ async def generate_payout_report(conn: Connection, year: int) -> bytes:
     payouts = await conn.fetch_many(PayoutRunForReport, query_string)
 
     #TODO: Is node id 1 always correct?
-    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1 as bigint) AND type='private';"
+    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1000 as bigint) AND type='private'"
     remaining_balances = await conn.fetch_one(RemainingBalances, remaining_balance_query)
 
     config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
@@ -71,4 +71,4 @@ async def generate_payout_report(conn: Connection, year: int) -> bytes:
         files["logo.svg"] = logo
 
     # TODO: Specify save location
-    return await render_report(template="payout_report", template_context=context.model_dump(), files=files)
+    return await render_report(template="payouts", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -1,0 +1,74 @@
+from calendar import day_name
+from datetime import datetime, timedelta
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel
+from sftkit.database import Connection
+
+from stustapay.bon.bon import BonConfig
+from stustapay.core.currency import get_currency_symbol
+from stustapay.core.schema.media import Blob
+from stustapay.core.schema.tree import RestrictedEventSettings
+from stustapay.core.service.media import fetch_blob
+from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
+from stustapay.reports.render import render_report
+
+
+class PayoutRunForReport(BaseModel):
+    set_done_at: datetime
+    n_payouts: int
+    total_payout_amount: float
+    total_donation_amount: float
+
+
+class RemainingBalances(BaseModel):
+    remaining_balances: float
+
+
+class PayoutReportContext(BaseModel):
+    event_name: str
+    render_logo: bool
+    config: BonConfig
+    date: datetime
+    payouts: list[PayoutRunForReport]
+    remaining_balances: float
+    currency_symbol: str
+
+
+async def generate_payout_report(conn: Connection, year: int) -> bytes:
+    node = await fetch_node(conn=conn, node_id=1)
+    assert node is not None
+    assert node.event_node_id is not None
+    event = await fetch_event_for_node(conn=conn, node=node)
+
+    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at;"
+    payouts = await conn.fetch_many(PayoutRunForReport, query_string)
+
+    #TODO: Is node id 1 always correct?
+    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1 as bigint) AND type='private';"
+    remaining_balances = await conn.fetch_one(RemainingBalances, remaining_balance_query)
+
+    config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
+
+    event_design = await fetch_event_design(conn=conn, node_id=node.event_node_id)
+    logo = None
+    if event_design.bon_logo_blob_id is not None:
+        logo = await fetch_blob(conn=conn, blob_id=event_design.bon_logo_blob_id)
+
+    context = PayoutReportContext(
+        event_name=event.bon_title,
+        render_logo=logo is not None,
+        config=config,
+        date=datetime.today().date(),
+        payouts=payouts,
+        remaining_balances=remaining_balances,
+        currency_symbol=get_currency_symbol(event.currency_identifier),
+    )
+    files = {}
+    if logo:
+        files["logo.svg"] = logo
+
+    # TODO: Specify save location
+    return await render_report(template="payout_report", template_context=context.model_dump(), files=files)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -44,7 +44,9 @@ async def generate_payout_report(conn: Connection, node: Node) -> bytes:
     )
 
     remaining_accounts = await conn.fetch_one(
-        RemainingBalances, "SELECT sum(balance) as remaining_balances, count(balance) as remaining_customers FROM account WHERE node_id=$1 AND type='private'", node.event_node_id
+        RemainingBalances,
+        "SELECT sum(balance) as remaining_balances, count(balance) as remaining_customers FROM account WHERE node_id=$1 AND type='private'",
+        node.event_node_id,
     )
 
     config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -1,16 +1,9 @@
-from calendar import day_name
-from datetime import datetime, timedelta
-from typing import Optional
-
-import numpy as np
-import pandas as pd
+from datetime import datetime
 from pydantic import BaseModel
 from sftkit.database import Connection
 
 from stustapay.bon.bon import BonConfig
 from stustapay.core.currency import get_currency_symbol
-from stustapay.core.schema.media import Blob
-from stustapay.core.schema.tree import RestrictedEventSettings
 from stustapay.core.service.media import fetch_blob
 from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
 from stustapay.reports.render import render_report
@@ -43,7 +36,7 @@ async def generate_payout_report(conn: Connection, year: int) -> bytes:
     assert node.event_node_id is not None
     event = await fetch_event_for_node(conn=conn, node=node)
 
-    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at;"
+    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at"
     payouts = await conn.fetch_many(PayoutRunForReport, query_string)
 
     #TODO: Is node id 1 always correct?

--- a/stustapay/reports/payout_report.py
+++ b/stustapay/reports/payout_report.py
@@ -1,11 +1,13 @@
 from datetime import datetime
+
 from pydantic import BaseModel
 from sftkit.database import Connection
 
 from stustapay.bon.bon import BonConfig
 from stustapay.core.currency import get_currency_symbol
+from stustapay.core.schema.tree import Node
 from stustapay.core.service.media import fetch_blob
-from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node, fetch_node
+from stustapay.core.service.tree.common import fetch_event_design, fetch_event_for_node
 from stustapay.reports.render import render_report
 
 
@@ -17,7 +19,7 @@ class PayoutRunForReport(BaseModel):
 
 
 class RemainingBalances(BaseModel):
-    remaining_balances: float | None = 0.
+    remaining_balances: float | None = 0.0
 
 
 class PayoutReportContext(BaseModel):
@@ -30,18 +32,19 @@ class PayoutReportContext(BaseModel):
     currency_symbol: str
 
 
-async def generate_payout_report(conn: Connection, year: int) -> bytes:
-    node = await fetch_node(conn=conn, node_id=1)
-    assert node is not None
+async def generate_payout_report(conn: Connection, node: Node) -> bytes:
     assert node.event_node_id is not None
     event = await fetch_event_for_node(conn=conn, node=node)
 
-    query_string = f"SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE created_at > '{year}-01-01' AND done=TRUE ORDER BY set_done_at"
-    payouts = await conn.fetch_many(PayoutRunForReport, query_string)
+    payouts = await conn.fetch_many(
+        PayoutRunForReport,
+        "SELECT set_done_at, n_payouts, total_payout_amount, total_donation_amount FROM payout_run_with_stats WHERE node_id = $1 AND done=TRUE ORDER BY set_done_at",
+        node.event_node_id,
+    )
 
-    #TODO: Is node id 1 always correct?
-    remaining_balance_query = "SELECT sum(balance) FROM account WHERE node_id=cast(1000 as bigint) AND type='private'"
-    remaining_balances = await conn.fetch_one(RemainingBalances, remaining_balance_query)
+    remaining_balances = await conn.fetch_one(
+        RemainingBalances, "SELECT sum(balance) FROM account WHERE node_id=$1 AND type='private'", node.event_node_id
+    )
 
     config = BonConfig(ust_id=event.ust_id, address=event.bon_address, issuer=event.bon_issuer, title=event.bon_title)
 

--- a/stustapay/reports/render.py
+++ b/stustapay/reports/render.py
@@ -1,11 +1,28 @@
 from pathlib import Path
 
-from mako.template import Template
+from mako.lookup import TemplateLookup
 from weasyprint import CSS, HTML
 
 from stustapay.core.schema.media import Blob
 
 asset_dir = Path(__file__).parent / "assets"
+
+template_lookup = TemplateLookup(directories=[str(asset_dir)])
+
+
+def create_format_money(currency_symbol: str):
+    def format_money(value):
+        return f"{value:8.2f}{currency_symbol}".replace(".", ",")
+
+    return format_money
+
+
+def format_datetime(value):
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def format_percent(value):
+    return f"{value * 100:5.2f}%".replace(".", ",")
 
 
 async def render_report(template: str, template_context: dict, files: dict[str, Blob]) -> bytes:
@@ -14,12 +31,20 @@ async def render_report(template: str, template_context: dict, files: dict[str, 
         if filename and filename in files:
             file = files[filename]
             return {"string": file.data, "mime_type": file.mime_type}
-        # return default_url_fetcher(url)
         return None  # disallow external fetching of resources
 
     # TODO: use a module_directory for template caching
-    report_template = Template(filename=str(asset_dir / f"{template}.html.mako"))
-    rendered_template = report_template.render(**template_context)
+
+    functions = {
+        "format_money": create_format_money(
+            template_context.get("currency_symbol", "€")
+        ),  # TODO: check if euro symbol default makes sense here
+        "format_datetime": format_datetime,
+        "format_percent": format_percent,
+    }
+
+    report_template = template_lookup.get_template(f"{template}.html.mako")
+    rendered_template = report_template.render(**template_context, **functions)
     html = HTML(string=rendered_template, url_fetcher=url_fetcher)
     stylesheet = CSS(asset_dir / f"{template}.css")
     return html.write_pdf(stylesheets=[stylesheet])

--- a/web/apps/administration/src/api/api.ts
+++ b/web/apps/administration/src/api/api.ts
@@ -20,10 +20,13 @@ import {
   UserTagDetailRead,
   api as generatedApi,
   GenerateTestBonApiArg,
-  GenerateTestReportApiArg,
+  GenerateTestRevenueReportApiArg,
   Terminal,
   GenerateRevenueReportApiArg,
   Transaction,
+  GenerateTestDailyReportApiArg,
+  GeneratePayoutReportApiArg,
+  GenerateDailyReportApiArg,
 } from "./generated/api";
 import { convertEntityAdaptorSelectors, generateCacheKeys } from "./utils";
 
@@ -176,9 +179,9 @@ export const api = generatedApi.enhanceEndpoints({
     listPayoutRuns: {
       providesTags: (result) => generateCacheKeys("payouts", result),
     },
-    generateTestReport: {
-      query: (queryArg: GenerateTestReportApiArg) => ({
-        url: `/tree/events/${queryArg.nodeId}/generate-test-report`,
+    generateTestRevenueReport: {
+      query: (queryArg: GenerateTestRevenueReportApiArg) => ({
+        url: `/tree/events/${queryArg.nodeId}/generate-test-revenuereport`,
         method: "POST",
         responseHandler: async (resp: Response) => {
           const blob = await resp.blob();
@@ -190,6 +193,40 @@ export const api = generatedApi.enhanceEndpoints({
     generateRevenueReport: {
       query: (queryArg: GenerateRevenueReportApiArg) => ({
         url: `/tree/nodes/${queryArg.nodeId}/generate-revenue-report`,
+        method: "POST",
+        responseHandler: async (resp: Response) => {
+          const blob = await resp.blob();
+          return window.URL.createObjectURL(blob);
+        },
+      }),
+      invalidatesTags: [],
+    },
+    generateTestDailyReport: {
+      query: (queryArg: GenerateTestDailyReportApiArg) => ({
+        url: `/tree/events/${queryArg.nodeId}/generate-test-daily-report`,
+        method: "POST",
+        responseHandler: async (resp: Response) => {
+          const blob = await resp.blob();
+          return window.URL.createObjectURL(blob);
+        },
+      }),
+      invalidatesTags: [],
+    },
+    generateDailyReport: {
+      query: (queryArg: GenerateDailyReportApiArg) => ({
+        url: `/tree/nodes/${queryArg.nodeId}/generate-daily-report`,
+        method: "POST",
+        body: queryArg.generateDailyReportPayload,
+        responseHandler: async (resp: Response) => {
+          const blob = await resp.blob();
+          return window.URL.createObjectURL(blob);
+        },
+      }),
+      invalidatesTags: [],
+    },
+    generatePayoutReport: {
+      query: (queryArg: GeneratePayoutReportApiArg) => ({
+        url: `/tree/nodes/${queryArg.nodeId}/generate-payout-report`,
         method: "POST",
         responseHandler: async (resp: Response) => {
           const blob = await resp.blob();

--- a/web/apps/administration/src/api/generated/api.ts
+++ b/web/apps/administration/src/api/generated/api.ts
@@ -1178,12 +1178,28 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ["tree"],
       }),
-      generateTestReport: build.mutation<GenerateTestReportApiResponse, GenerateTestReportApiArg>({
+      generateTestRevenueReport: build.mutation<GenerateTestRevenueReportApiResponse, GenerateTestRevenueReportApiArg>({
         query: (queryArg) => ({ url: `/tree/events/${queryArg.nodeId}/generate-test-report`, method: "POST" }),
         invalidatesTags: ["tree"],
       }),
       generateRevenueReport: build.mutation<GenerateRevenueReportApiResponse, GenerateRevenueReportApiArg>({
         query: (queryArg) => ({ url: `/tree/nodes/${queryArg.nodeId}/generate-revenue-report`, method: "POST" }),
+        invalidatesTags: ["tree"],
+      }),
+      generateDailyReport: build.mutation<GenerateDailyReportApiResponse, GenerateDailyReportApiArg>({
+        query: (queryArg) => ({
+          url: `/tree/nodes/${queryArg.nodeId}/generate-daily-report`,
+          method: "POST",
+          body: queryArg.generateDailyReportPayload,
+        }),
+        invalidatesTags: ["tree"],
+      }),
+      generateTestDailyReport: build.mutation<GenerateTestDailyReportApiResponse, GenerateTestDailyReportApiArg>({
+        query: (queryArg) => ({ url: `/tree/events/${queryArg.nodeId}/generate-test-daily-report`, method: "POST" }),
+        invalidatesTags: ["tree"],
+      }),
+      generatePayoutReport: build.mutation<GeneratePayoutReportApiResponse, GeneratePayoutReportApiArg>({
+        query: (queryArg) => ({ url: `/tree/nodes/${queryArg.nodeId}/generate-payout-report`, method: "POST" }),
         invalidatesTags: ["tree"],
       }),
       configureSumupToken: build.mutation<ConfigureSumupTokenApiResponse, ConfigureSumupTokenApiArg>({
@@ -1989,12 +2005,25 @@ export type GenerateWebhookUrlApiArg = {
   nodeId: number;
   generateWebhookPayload: GenerateWebhookPayload;
 };
-export type GenerateTestReportApiResponse = /** status 200 Successful Response */ any;
-export type GenerateTestReportApiArg = {
+export type GenerateTestRevenueReportApiResponse = /** status 200 Successful Response */ any;
+export type GenerateTestRevenueReportApiArg = {
   nodeId: number;
 };
 export type GenerateRevenueReportApiResponse = /** status 200 Successful Response */ any;
 export type GenerateRevenueReportApiArg = {
+  nodeId: number;
+};
+export type GenerateDailyReportApiResponse = /** status 200 Successful Response */ any;
+export type GenerateDailyReportApiArg = {
+  nodeId: number;
+  generateDailyReportPayload: GenerateDailyReportPayload;
+};
+export type GenerateTestDailyReportApiResponse = /** status 200 Successful Response */ any;
+export type GenerateTestDailyReportApiArg = {
+  nodeId: number;
+};
+export type GeneratePayoutReportApiResponse = /** status 200 Successful Response */ any;
+export type GeneratePayoutReportApiArg = {
   nodeId: number;
 };
 export type ConfigureSumupTokenApiResponse = /** status 200 Successful Response */ any;
@@ -3379,6 +3408,10 @@ export type WebhookType = "pretix";
 export type GenerateWebhookPayload = {
   webhook_type: WebhookType;
 };
+export type GenerateDailyReportPayload = {
+  relevant_node_ids: number[];
+  report_date: string;
+};
 export type SumUpTokenPayload = {
   authorization_code: string;
 };
@@ -3666,8 +3699,11 @@ export const {
   useCheckPretixConnectionMutation,
   useFetchPretixProductsMutation,
   useGenerateWebhookUrlMutation,
-  useGenerateTestReportMutation,
+  useGenerateTestRevenueReportMutation,
   useGenerateRevenueReportMutation,
+  useGenerateDailyReportMutation,
+  useGenerateTestDailyReportMutation,
+  useGeneratePayoutReportMutation,
   useConfigureSumupTokenMutation,
   useListAuditLogsQuery,
   useLazyListAuditLogsQuery,

--- a/web/apps/administration/src/app/Router.tsx
+++ b/web/apps/administration/src/app/Router.tsx
@@ -5,7 +5,15 @@ import { AuthenticatedRoot, PrivilegeGuard, UnauthenticatedRoot } from "./layout
 import { AccountDetail, AccountPageLayout, FindAccounts, SystemAccountList } from "./routes/accounts";
 import { Login, Profile } from "./routes/auth";
 import { CashierCloseOut, CashierDetail, CashierList, CashierShiftDetail } from "./routes/cashiers";
-import { EventCreate, NodeOverview, MoneyOverview, NodePageLayout, NodeSettings, NodeCreate } from "./routes/nodes";
+import {
+  EventCreate,
+  NodeOverview,
+  MoneyOverview,
+  NodePageLayout,
+  NodeSettings,
+  NodeCreate,
+  RevenueReports,
+} from "./routes/nodes";
 import { NodeStats } from "./routes/nodes/stats";
 import { OrderBon, OrderDetail, SaleEdit, TransactionDetail } from "./routes/orders";
 import { PayoutRunCreate, PayoutRunDetail, PayoutRunList } from "./routes/payouts";
@@ -107,6 +115,10 @@ const router = createBrowserRouter([
               {
                 path: "audit-logs",
                 element: <AuditLogList />,
+              },
+              {
+                path: "reports",
+                element: <RevenueReports />,
               },
               {
                 path: "system-accounts",

--- a/web/apps/administration/src/app/routes/nodes/EventPageLayout.tsx
+++ b/web/apps/administration/src/app/routes/nodes/EventPageLayout.tsx
@@ -8,6 +8,7 @@ import {
   Settings as SettingsIcon,
   HistoryEdu as HistoryEduIcon,
   List as ListIcon,
+  Receipt as ReceiptIcon,
 } from "@mui/icons-material";
 import { Box, Tab, Tabs } from "@mui/material";
 import * as React from "react";
@@ -35,6 +36,9 @@ const getActiveTab = (nodeId: number, location: string) => {
   }
   if (location.startsWith(`/node/${nodeId}/audit-logs`)) {
     return `/node/${nodeId}/audit-logs`;
+  }
+  if (location.startsWith(`/node/${nodeId}/reports`)) {
+    return `/node/${nodeId}/reports`;
   }
   return `/node/${nodeId}`;
 };
@@ -66,6 +70,14 @@ export const EventPageLayout: React.FC<{ node: Node }> = ({ node }) => {
           icon={<LeaderboardIcon />}
           iconPosition="start"
           to={`${nodeUrl}/stats`}
+        />
+        <Tab
+          label={t("nodes.reports")}
+          component={RouterLink}
+          value={`${nodeUrl}/reports`}
+          icon={<ReceiptIcon />}
+          iconPosition="start"
+          to={`${nodeUrl}/reports`}
         />
         <Tab
           label={t("systemAccounts")}

--- a/web/apps/administration/src/app/routes/nodes/NodePageLayout.tsx
+++ b/web/apps/administration/src/app/routes/nodes/NodePageLayout.tsx
@@ -4,6 +4,7 @@ import {
   Leaderboard as LeaderboardIcon,
   Settings as SettingsIcon,
   List as ListIcon,
+  Receipt as ReceiptIcon,
 } from "@mui/icons-material";
 import { Box, Tab, Tabs } from "@mui/material";
 import { Loading } from "@stustapay/components";
@@ -21,6 +22,9 @@ const getActiveTab = (nodeId: number, location: string) => {
   }
   if (location.startsWith(`/node/${nodeId}/audit-logs`)) {
     return `/node/${nodeId}/audit-logs`;
+  }
+  if (location.startsWith(`/node/${nodeId}/reports`)) {
+    return `/node/${nodeId}/reports`;
   }
   return `/node/${nodeId}`;
 };
@@ -61,14 +65,24 @@ export const NodePageLayout: React.FC = () => {
           to={nodeUrl}
         />
         {node.event_node_id != null && (
-          <Tab
-            label={t("nodes.statistics")}
-            component={RouterLink}
-            value={`${nodeUrl}/stats`}
-            icon={<LeaderboardIcon />}
-            iconPosition="start"
-            to={`${nodeUrl}/stats`}
-          />
+          <>
+            <Tab
+              label={t("nodes.statistics")}
+              component={RouterLink}
+              value={`${nodeUrl}/stats`}
+              icon={<LeaderboardIcon />}
+              iconPosition="start"
+              to={`${nodeUrl}/stats`}
+            />
+            <Tab
+              label={t("nodes.reports")}
+              component={RouterLink}
+              value={`${nodeUrl}/reports`}
+              icon={<ReceiptIcon />}
+              iconPosition="start"
+              to={`${nodeUrl}/reports`}
+            />
+          </>
         )}
         <Tab
           label={t("auditLog.auditLogs")}

--- a/web/apps/administration/src/app/routes/nodes/RevenueReports.tsx
+++ b/web/apps/administration/src/app/routes/nodes/RevenueReports.tsx
@@ -1,0 +1,103 @@
+import { useCurrentNode } from "@/hooks";
+import * as React from "react";
+import { Stack } from "@mui/material";
+import { Receipt as ReceiptIcon } from "@mui/icons-material";
+import {
+  NodeSeenByUser,
+  useGenerateDailyReportMutation,
+  useGeneratePayoutReportMutation,
+  useGenerateRevenueReportMutation,
+} from "@/api";
+import { LoadingButton } from "@mui/lab";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-toastify";
+import { NodeMultiSelect } from "@/components";
+import { DatePicker } from "@mui/x-date-pickers";
+import { DateTime } from "luxon";
+
+async function openReportPreview<T>(args: T, generationFunction: (args: T) => Promise<any>) {
+  try {
+    console.log(args);
+    const resp = await generationFunction(args);
+    console.log(resp);
+    const pdfUrl = (resp as any).data;
+    if (pdfUrl === undefined) {
+      console.log(resp);
+      toast.error("Error generating report");
+    } else {
+      window.open(pdfUrl);
+    }
+  } catch (e) {
+    toast.error("Error generating report");
+  }
+}
+
+export const RevenueReports: React.FC = () => {
+  const { t } = useTranslation();
+  const { currentNode } = useCurrentNode();
+  const [selectedNodes, setSelectedNodes] = React.useState<NodeSeenByUser[]>([]);
+  const [reportDate, setReportDate] = React.useState<string | null>(null);
+  const [generateRevenueReport, { isLoading: revenueReportGenerating }] = useGenerateRevenueReportMutation();
+  const [generateDailyReport, { isLoading: dailyReportGenerating }] = useGenerateDailyReportMutation();
+  const [generatePayoutReport, { isLoading: payoutReportGenerating }] = useGeneratePayoutReportMutation();
+
+  return (
+    <Stack spacing={2}>
+      <LoadingButton
+        variant="contained"
+        onClick={async () => await openReportPreview({ nodeId: currentNode.id }, generateRevenueReport)}
+        loading={revenueReportGenerating}
+        startIcon={<ReceiptIcon />}
+        loadingPosition="start"
+      >
+        {t("overview.generateRevenueReport")}
+      </LoadingButton>
+      <LoadingButton
+        variant="contained"
+        onClick={async () => await openReportPreview({ nodeId: currentNode.id }, generatePayoutReport)}
+        loading={payoutReportGenerating}
+        startIcon={<ReceiptIcon />}
+        loadingPosition="start"
+      >
+        {t("overview.generatePayoutReport")}
+      </LoadingButton>
+
+      <NodeMultiSelect value={selectedNodes} onChange={setSelectedNodes} label={t("overview.selectedNodesForReport")} />
+      <DatePicker
+        value={reportDate ? DateTime.fromISO(reportDate) : null}
+        onChange={(value) => {
+          const date = value?.toISODate();
+          if (date) {
+            setReportDate(date);
+          }
+        }}
+        reduceAnimations
+        slotProps={{
+          textField: {
+            variant: "standard",
+          },
+        }}
+      />
+      <LoadingButton
+        variant="contained"
+        onClick={async () => {
+          await openReportPreview(
+            {
+              nodeId: currentNode.id,
+              generateDailyReportPayload: {
+                relevant_node_ids: selectedNodes.map((node) => node.id),
+                report_date: reportDate ?? "", // TODO
+              },
+            },
+            generateDailyReport
+          );
+        }}
+        loading={dailyReportGenerating}
+        startIcon={<ReceiptIcon />}
+        loadingPosition="start"
+      >
+        {t("overview.generateDailyReport")}
+      </LoadingButton>
+    </Stack>
+  );
+};

--- a/web/apps/administration/src/app/routes/nodes/event-settings/TabBon.tsx
+++ b/web/apps/administration/src/app/routes/nodes/event-settings/TabBon.tsx
@@ -2,7 +2,7 @@ import {
   BonJsonRead,
   RestrictedEventSettings,
   useGenerateTestBonMutation,
-  useGenerateTestReportMutation,
+  useGenerateTestRevenueReportMutation,
   useGetEventDesignQuery,
   useUpdateEventMutation,
 } from "@/api";
@@ -63,7 +63,7 @@ export const TabBon: React.FC<{ nodeId: number; eventSettings: RestrictedEventSe
   const [updateEvent] = useUpdateEventMutation();
   const [previewBon, { isLoading: bonPreviewGenerating }] = useGenerateTestBonMutation();
   const [bonPreview, setBonPreview] = React.useState<BonJsonRead | null>(null);
-  const [previewReport, { isLoading: reportPreviewGenerating }] = useGenerateTestReportMutation();
+  const [previewReport, { isLoading: reportPreviewGenerating }] = useGenerateTestRevenueReportMutation();
 
   const handleSubmit = (values: BonSettings, { setSubmitting }: FormikHelpers<BonSettings>) => {
     setSubmitting(true);

--- a/web/apps/administration/src/app/routes/nodes/index.ts
+++ b/web/apps/administration/src/app/routes/nodes/index.ts
@@ -5,3 +5,4 @@ export * from "./node-overview";
 export * from "./node-settings";
 export * from "./EventCreate";
 export * from "./NodeCreate";
+export * from "./RevenueReports";

--- a/web/apps/administration/src/app/routes/nodes/node-overview/NodeOverview.tsx
+++ b/web/apps/administration/src/app/routes/nodes/node-overview/NodeOverview.tsx
@@ -1,51 +1,13 @@
 import { useCurrentNode } from "@/hooks";
 import * as React from "react";
 import { EventOverview } from "../event-overview";
-import { Stack } from "@mui/material";
-import { Receipt as ReceiptIcon } from "@mui/icons-material";
-import { useGenerateRevenueReportMutation } from "@/api";
-import { LoadingButton } from "@mui/lab";
-import { useTranslation } from "react-i18next";
-import { toast } from "react-toastify";
 
 export const NodeOverview: React.FC = () => {
-  const { t } = useTranslation();
   const { currentNode } = useCurrentNode();
-  const [generateReport, { isLoading: reportGenerating }] = useGenerateRevenueReportMutation();
 
   if (currentNode.event != null) {
     return <EventOverview />;
   }
 
-  const openReportPreview = async () => {
-    try {
-      console.log("starting report preview");
-      const resp = await generateReport({
-        nodeId: currentNode.id,
-      });
-      const pdfUrl = (resp as any).data;
-      if (pdfUrl === undefined) {
-        console.log(resp);
-        toast.error("Error generating report");
-      } else {
-        window.open(pdfUrl);
-      }
-    } catch (e) {
-      toast.error("Error generating report");
-    }
-  };
-
-  return (
-    <Stack spacing={2}>
-      <LoadingButton
-        variant="contained"
-        onClick={openReportPreview}
-        loading={reportGenerating}
-        startIcon={<ReceiptIcon />}
-        loadingPosition="start"
-      >
-        {t("overview.generateRevenueReport")}
-      </LoadingButton>
-    </Stack>
-  );
+  return null;
 };

--- a/web/apps/administration/src/components/NodeMultiSelcet.tsx
+++ b/web/apps/administration/src/components/NodeMultiSelcet.tsx
@@ -3,13 +3,13 @@ import { useCurrentNode } from "@/hooks";
 import { Select } from "@stustapay/components";
 import * as React from "react";
 
-export type NodeSelectProps = {
+export type NodeMultiSelectProps = {
   label: string;
-  value: NodeSeenByUser;
-  onChange: (value: NodeSeenByUser | null) => void;
+  value: NodeSeenByUser[];
+  onChange: (value: NodeSeenByUser[]) => void;
 };
 
-export const NodeSelect: React.FC<NodeSelectProps> = ({ ...props }) => {
+export const NodeMultiSelect: React.FC<NodeMultiSelectProps> = ({ onChange, ...props }) => {
   const { currentNode } = useCurrentNode();
 
   const options = React.useMemo(() => {
@@ -22,5 +22,21 @@ export const NodeSelect: React.FC<NodeSelectProps> = ({ ...props }) => {
     return result;
   }, [currentNode]);
 
-  return <Select multiple={false} options={options} formatOption={(v: NodeSeenByUser) => v.name} {...props} />;
+  const handleChange = React.useCallback(
+    (value: NodeSeenByUser[] | null) => {
+      onChange(value ?? []);
+    },
+    [onChange]
+  );
+
+  return (
+    <Select
+      checkboxes={true}
+      multiple={true}
+      options={options}
+      formatOption={(v: NodeSeenByUser) => v.name}
+      onChange={handleChange}
+      {...props}
+    />
+  );
 };

--- a/web/apps/administration/src/components/index.ts
+++ b/web/apps/administration/src/components/index.ts
@@ -8,3 +8,4 @@ export * from "./ExpandableLinkMenu";
 export * from "./MarkdownEditor";
 export * from "./graphs";
 export * from "./NodeSelect";
+export * from "./NodeMultiSelcet";

--- a/web/apps/administration/src/locales/en/translations.ts
+++ b/web/apps/administration/src/locales/en/translations.ts
@@ -63,6 +63,7 @@ export const translations = {
     overview: "Overview",
     statistics: "Stats",
     settings: "Settings",
+    reports: "Reports",
   },
   auditLog: {
     auditLogs: "Audit logs",
@@ -254,7 +255,10 @@ export const translations = {
     showRevenue: "Show revenue",
     warningEventDatesNeedConfiguration:
       "Please configure the start / end times for this event as well as the daily end time in the event settings",
+    selectedNodesForReport: "Selected nodes for report",
     generateRevenueReport: "Generate revenue report",
+    generateDailyReport: "Generate daily report",
+    generatePayoutReport: "Generate payout report",
   },
   ticket: {
     name: "Name",


### PR DESCRIPTION
Generate two new pdf reports:
- Daily revenues split by type of payment/payment method/node/...
- Overview over online payout runs and remaining balances of customers

Remaining Todos:
- Automatically split locations at first tree level instead of manual assignment via dictionary
- Better handling of shifted day breaks through event configuration
- Is the event parent node hardcoded as 1?
- Better formatting of reports (what happens if lines are too long? Do pagebreaks work? Vertical lines in table?)
- Integration into web UI