### PR TITLE
fix: add quiet zone to QR codes in invoices (#581)

### DIFF
--- a/app/libssp/src/main/java/de/stustapay/libssp/ui/barcode/QRCode.kt
+++ b/app/libssp/src/main/java/de/stustapay/libssp/ui/barcode/QRCode.kt
@@ -13,7 +13,7 @@ import com.google.zxing.qrcode.QRCodeWriter
 
 @Composable
 fun QRCode(data: String = "https://www.youtube.com/watch?v=XfELJU1mRMg") {
-    val hints = hashMapOf<EncodeHintType, Int>().also { it[EncodeHintType.MARGIN] = 1 }
+    val hints = hashMapOf<EncodeHintType, Int>().also { it[EncodeHintType.MARGIN] = 4 }
     val qrCodeRaw = QRCodeWriter().encode(
         data, BarcodeFormat.QR_CODE, 512, 512, hints
     )

--- a/web/libs/components/src/lib/bon/BonDisplay.module.css
+++ b/web/libs/components/src/lib/bon/BonDisplay.module.css
@@ -1,3 +1,11 @@
 .tseTable td:nth-child(2) {
     width: 70%;
 }
+
+.qrCodeContainer {
+    background-color: white;
+    padding: 16px;
+    border-radius: 8px;
+    display: inline-block;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/web/libs/components/src/lib/bon/BonDisplay.tsx
+++ b/web/libs/components/src/lib/bon/BonDisplay.tsx
@@ -278,12 +278,14 @@ const SignatureDetails: React.FC<{ bon: IBon }> = ({ bon: { order } }) => {
 
       <Box display="flex" justifyContent="center" alignItems="center" marginTop={3}>
         <Box maxWidth="400px">
-          <QRCode
-            size={256}
-            style={{ height: "auto", width: "100%" }}
-            value={order.tse_qr_code_text}
-            viewBox={`0 0 256 256`}
-          />
+          <div className={styles.qrCodeContainer}>
+            <QRCode
+              size={256}
+              style={{ height: "auto", width: "100%" }}
+              value={order.tse_qr_code_text}
+              viewBox={`0 0 256 256`}
+            />
+          </div>
         </Box>
       </Box>
     </Paper>


### PR DESCRIPTION
- Wrapped QR code in BonDisplay.tsx inside a div.qrCodeContainer with white background + padding
- Added CSS rule .qrCodeContainer for styling (padding, white bg, border radius, shadow)
- Increased QR code margin from 1 → 4 modules in QRCode.kt (Android)

fixes #581 