### PR TITLE
accept more valid email adresses

### DIFF
--- a/web/apps/administration/src/app/routes/nodes/event-settings/TabCustomerPortal.tsx
+++ b/web/apps/administration/src/app/routes/nodes/event-settings/TabCustomerPortal.tsx
@@ -11,7 +11,7 @@ import { RestrictedEventSettings, useUpdateEventMutation } from "@/api";
 
 export const CustomerPortalSettingsSchema = z.object({
   customer_portal_url: z.string().url(),
-  customer_portal_contact_email: z.string().email(),
+  customer_portal_contact_email: z.string().email({ pattern: z.regexes.html5Email }),
   customer_portal_about_page_url: z.string().url(),
   customer_portal_data_privacy_url: z.string().url(),
   customer_portal_feedback_url: z.string().url().optional(),

--- a/web/apps/administration/src/app/routes/nodes/event-settings/TabMail.tsx
+++ b/web/apps/administration/src/app/routes/nodes/event-settings/TabMail.tsx
@@ -17,7 +17,7 @@ const requiredIssue = {
 export const MailSettingsSchema = z
   .object({
     email_enabled: z.boolean(),
-    email_default_sender: z.string().email().optional().nullable(),
+    email_default_sender: z.string().email({ pattern: z.regexes.html5Email }).optional().nullable(),
     email_smtp_host: z.string().optional().nullable(),
     email_smtp_port: z.number().int().optional().nullable(),
     email_smtp_username: z.string().optional().nullable(),

--- a/web/apps/administration/src/app/routes/nodes/event-settings/TabPayout.tsx
+++ b/web/apps/administration/src/app/routes/nodes/event-settings/TabPayout.tsx
@@ -38,7 +38,7 @@ export const PayoutSettingsSchema = z
     payout_done_message: zodExtension.undefineableString(),
     payout_registered_subject: zodExtension.undefineableString(),
     payout_registered_message: zodExtension.undefineableString(),
-    payout_sender: z.string().email().optional(),
+    payout_sender: z.string().email({ pattern: z.regexes.html5Email }).optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.sepa_enabled) {

--- a/web/apps/customerportal/src/app/routes/PayoutInfo.tsx
+++ b/web/apps/customerportal/src/app/routes/PayoutInfo.tsx
@@ -66,7 +66,7 @@ export const PayoutInfo: React.FC = () => {
         });
       }
     }),
-    email: z.string().email(),
+    email: z.string().email({ pattern: z.regexes.html5Email }),
     privacy_policy: z.boolean().refine((val) => val, {
       message: t("payout.mustAcceptPrivacyPolicy"),
     }),


### PR DESCRIPTION
By default, Zod is very restrictive regarding email addresses (`z.email()`). Instead, in stustapay, accept any email address that standard browsers accept in forms. See
https://zod.dev/api?id=emails#emails
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/email

This should fix issue #664